### PR TITLE
Remove target branch in the slack message

### DIFF
--- a/pipelines/common_mce_2.10.yaml
+++ b/pipelines/common_mce_2.10.yaml
@@ -615,7 +615,6 @@ spec:
           value: |
             :bangbang: <@$(params.slack-member-id)> PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
             - git source: $(params.git-url)/commit/$(params.revision)
-            - target branch: $(params.git-url)/tree/{{target_branch}}
             - output image: $(params.output-image)
             - see details: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/$(context.pipelineRun.namespace)/applications/$(params.konflux-application-name)/pipelineruns/$(context.pipelineRun.name)
         - name: secret-name


### PR DESCRIPTION
Remove the target branch since it can not be rendered:

<img width="1102" height="490" alt="image" src="https://github.com/user-attachments/assets/9db347ae-2672-40f8-a2f5-5b5a6601513a" />
