### PR TITLE
Fix konflux violations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,14 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Set metadata
-LABEL name="konflux-build-catalog" \
+LABEL \
+      name="multicluster-engine/konflux-build-catalog-rhel9" \
+      summary="konflux-build-catalog" \
       description="Konflux Build Catalog - Pipeline definitions" \
+      io.k8s.description="konflux-build-catalog" \
+      io.k8s.display-name="konflux-build-catalog" \
+      com.redhat.component="multicluster-engine-konflux-build-catalog" \
+      io.openshift.tags="data,images" \
       version="1.0.0"
 
 # Copy pipeline files to demonstrate this is a pipeline catalog


### PR DESCRIPTION
Fix https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/crt-redhat-acm-tenant/applications/konflux-build-catalog/pipelineruns/konflux-build-catalog-enterprise-contract-rf2w5/logs
```
Results:
✕ [Violation] labels.disallowed_inherited_labels
  ImageRef: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline@sha256:e54e1e8393a86074061ea6c55f1515f694e1725a78c200c9a33567c55f0079b8
  Reason: The "com.redhat.component" label should not be inherited from the parent image
  Term: com.redhat.component
  Title: Disallowed inherited labels
  Description: Check that certain labels on the image have different values than the labels from the parent image. If the label is
  inherited from the parent image but not redefined for the image, it will contain an incorrect value for the image. Use the rule
  data `disallowed_inherited_labels` key to set the list of labels to check, or the `fbc_disallowed_inherited_labels` key for fbc
  images. To exclude this rule add "labels.disallowed_inherited_labels:com.redhat.component" to the `exclude` section of the
  policy configuration.
  Solution: Update the image build process to overwrite the inherited labels.

✕ [Violation] labels.disallowed_inherited_labels
  ImageRef: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline@sha256:e54e1e8393a86074061ea6c55f1515f694e1725a78c200c9a33567c55f0079b8
  Reason: The "io.k8s.description" label should not be inherited from the parent image
  Term: io.k8s.description
  Title: Disallowed inherited labels
  Description: Check that certain labels on the image have different values than the labels from the parent image. If the label is
  inherited from the parent image but not redefined for the image, it will contain an incorrect value for the image. Use the rule
  data `disallowed_inherited_labels` key to set the list of labels to check, or the `fbc_disallowed_inherited_labels` key for fbc
  images. To exclude this rule add "labels.disallowed_inherited_labels:io.k8s.description" to the `exclude` section of the policy
  configuration.
  Solution: Update the image build process to overwrite the inherited labels.

✕ [Violation] labels.disallowed_inherited_labels
  ImageRef: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline@sha256:e54e1e8393a86074061ea6c55f1515f694e1725a78c200c9a33567c55f0079b8
  Reason: The "io.k8s.display-name" label should not be inherited from the parent image
  Term: io.k8s.display-name
  Title: Disallowed inherited labels
  Description: Check that certain labels on the image have different values than the labels from the parent image. If the label is
  inherited from the parent image but not redefined for the image, it will contain an incorrect value for the image. Use the rule
  data `disallowed_inherited_labels` key to set the list of labels to check, or the `fbc_disallowed_inherited_labels` key for fbc
  images. To exclude this rule add "labels.disallowed_inherited_labels:io.k8s.display-name" to the `exclude` section of the policy
  configuration.
  Solution: Update the image build process to overwrite the inherited labels.

✕ [Violation] labels.disallowed_inherited_labels
  ImageRef: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline@sha256:e54e1e8393a86074061ea6c55f1515f694e1725a78c200c9a33567c55f0079b8
  Reason: The "io.openshift.tags" label should not be inherited from the parent image
  Term: io.openshift.tags
  Title: Disallowed inherited labels
  Description: Check that certain labels on the image have different values than the labels from the parent image. If the label is
  inherited from the parent image but not redefined for the image, it will contain an incorrect value for the image. Use the rule
  data `disallowed_inherited_labels` key to set the list of labels to check, or the `fbc_disallowed_inherited_labels` key for fbc
  images. To exclude this rule add "labels.disallowed_inherited_labels:io.openshift.tags" to the `exclude` section of the policy
  configuration.
  Solution: Update the image build process to overwrite the inherited labels.

✕ [Violation] labels.disallowed_inherited_labels
  ImageRef: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline@sha256:e54e1e8393a86074061ea6c55f1515f694e1725a78c200c9a33567c55f0079b8
  Reason: The "summary" label should not be inherited from the parent image
  Term: summary
  Title: Disallowed inherited labels
  Description: Check that certain labels on the image have different values than the labels from the parent image. If the label is
  inherited from the parent image but not redefined for the image, it will contain an incorrect value for the image. Use the rule
  data `disallowed_inherited_labels` key to set the list of labels to check, or the `fbc_disallowed_inherited_labels` key for fbc
  images. To exclude this rule add "labels.disallowed_inherited_labels:summary" to the `exclude` section of the policy
  configuration.
  Solution: Update the image build process to overwrite the inherited labels.

✕ [Violation] labels.disallowed_inherited_labels
  ImageRef: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline@sha256:a0ef775ae3649fba21f8e64684f704c9f09c8df8ef41f6aaec33a2d8a5327b07
  Reason: The "com.redhat.component" label should not be inherited from the parent image
  Term: com.redhat.component
  Title: Disallowed inherited labels
  Description: Check that certain labels on the image have different values than the labels from the parent image. If the label is
  inherited from the parent image but not redefined for the image, it will contain an incorrect value for the image. Use the rule
  data `disallowed_inherited_labels` key to set the list of labels to check, or the `fbc_disallowed_inherited_labels` key for fbc
  images. To exclude this rule add "labels.disallowed_inherited_labels:com.redhat.component" to the `exclude` section of the
  policy configuration.
  Solution: Update the image build process to overwrite the inherited labels.

✕ [Violation] labels.disallowed_inherited_labels
  ImageRef: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline@sha256:a0ef775ae3649fba21f8e64684f704c9f09c8df8ef41f6aaec33a2d8a5327b07
  Reason: The "io.k8s.description" label should not be inherited from the parent image
  Term: io.k8s.description
  Title: Disallowed inherited labels
  Description: Check that certain labels on the image have different values than the labels from the parent image. If the label is
  inherited from the parent image but not redefined for the image, it will contain an incorrect value for the image. Use the rule
  data `disallowed_inherited_labels` key to set the list of labels to check, or the `fbc_disallowed_inherited_labels` key for fbc
  images. To exclude this rule add "labels.disallowed_inherited_labels:io.k8s.description" to the `exclude` section of the policy
  configuration.
  Solution: Update the image build process to overwrite the inherited labels.

✕ [Violation] labels.disallowed_inherited_labels
  ImageRef: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline@sha256:a0ef775ae3649fba21f8e64684f704c9f09c8df8ef41f6aaec33a2d8a5327b07
  Reason: The "io.k8s.display-name" label should not be inherited from the parent image
  Term: io.k8s.display-name
  Title: Disallowed inherited labels
  Description: Check that certain labels on the image have different values than the labels from the parent image. If the label is
  inherited from the parent image but not redefined for the image, it will contain an incorrect value for the image. Use the rule
  data `disallowed_inherited_labels` key to set the list of labels to check, or the `fbc_disallowed_inherited_labels` key for fbc
  images. To exclude this rule add "labels.disallowed_inherited_labels:io.k8s.display-name" to the `exclude` section of the policy
  configuration.
  Solution: Update the image build process to overwrite the inherited labels.

✕ [Violation] labels.disallowed_inherited_labels
  ImageRef: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline@sha256:a0ef775ae3649fba21f8e64684f704c9f09c8df8ef41f6aaec33a2d8a5327b07
  Reason: The "io.openshift.tags" label should not be inherited from the parent image
  Term: io.openshift.tags
  Title: Disallowed inherited labels
  Description: Check that certain labels on the image have different values than the labels from the parent image. If the label is
  inherited from the parent image but not redefined for the image, it will contain an incorrect value for the image. Use the rule
  data `disallowed_inherited_labels` key to set the list of labels to check, or the `fbc_disallowed_inherited_labels` key for fbc
  images. To exclude this rule add "labels.disallowed_inherited_labels:io.openshift.tags" to the `exclude` section of the policy
  configuration.
  Solution: Update the image build process to overwrite the inherited labels.

✕ [Violation] labels.disallowed_inherited_labels
  ImageRef: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline@sha256:a0ef775ae3649fba21f8e64684f704c9f09c8df8ef41f6aaec33a2d8a5327b07
  Reason: The "summary" label should not be inherited from the parent image
  Term: summary
  Title: Disallowed inherited labels
  Description: Check that certain labels on the image have different values than the labels from the parent image. If the label is
  inherited from the parent image but not redefined for the image, it will contain an incorrect value for the image. Use the rule
  data `disallowed_inherited_labels` key to set the list of labels to check, or the `fbc_disallowed_inherited_labels` key for fbc
  images. To exclude this rule add "labels.disallowed_inherited_labels:summary" to the `exclude` section of the policy
  configuration.
  Solution: Update the image build process to overwrite the inherited labels.
```