### PR TITLE
Remove temporary file cleanup from update-tekton-task-bundles workflow

### DIFF
--- a/.github/workflows/update-tekton-task-bundles.yaml
+++ b/.github/workflows/update-tekton-task-bundles.yaml
@@ -121,9 +121,6 @@ jobs:
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-          # Clean up temporary files before checking diff
-          rm -f combined_migration_data.json temp_migration_data.json merged_migration_data.json
-
           # Check if any pipeline files have changes
           PIPELINE_FILES=(
             "pipelines/common.yaml"


### PR DESCRIPTION
The temporary file cleanup is no longer needed as the workflow has been refactored to not create these temporary files.