### PR TITLE
chore: migrate clamav-scan task from 0.2 to 0.3

### DIFF
--- a/pipelines/common.yaml
+++ b/pipelines/common.yaml
@@ -371,7 +371,7 @@ spec:
           - name: name
             value: clamav-scan
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:7749146f7e4fe530846f1b15c9366178ec9f44776ef1922a60d3e7e2b8c6426b
+            value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:cce2dfcc5bd6e91ee54aacdadad523b013eeae5cdaa7f6a4624b8cbcc040f439
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common_mce_2.10.yaml
+++ b/pipelines/common_mce_2.10.yaml
@@ -408,7 +408,7 @@ spec:
           - name: name
             value: clamav-scan
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:7749146f7e4fe530846f1b15c9366178ec9f44776ef1922a60d3e7e2b8c6426b
+            value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:cce2dfcc5bd6e91ee54aacdadad523b013eeae5cdaa7f6a4624b8cbcc040f439
           - name: kind
             value: task
         resolver: bundles


### PR DESCRIPTION
This PR migrates the clamav-scan Tekton task bundle from version 0.2 to 0.3 in both pipeline files.

## Changes Made
- Updated  to use clamav-scan:0.3
- Updated  to use clamav-scan:0.3

## Key Improvements in clamav-scan v0.3
- **Performance**: Uses clamdscan (daemon mode) instead of clamscan for better performance
- **Multi-threading**: Introduces clamd-max-threads parameter (replaces scan-threads)
- **Multi-arch support**: Adds image-arch parameter for better multi-architecture support
- **Resource optimization**: Reduces memory limits from 16Gi to 8Gi, updates CPU requests from 1 to 500m

## Compatibility
The migration is backward compatible as:
- The task only uses the required  and  parameters
- All new parameters have sensible defaults
- No changes needed to the pipeline task configuration

## Testing
- [x] Verified bundle references are correctly updated
- [x] Confirmed parameter compatibility between versions
- [ ] Pipeline execution testing (will be done via CI)

Resolves #59
Resolves #60