### PR TITLE
Update Tekton CEL expressions to trigger only on corresponding pipeline file changes

### DIFF
--- a/.tekton/common-pipeline-fbc-pull-request.yaml
+++ b/.tekton/common-pipeline-fbc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && "pipelines/common-fbc.yaml".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-build-catalog

--- a/.tekton/common-pipeline-fbc-pull-request.yaml
+++ b/.tekton/common-pipeline-fbc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && "pipelines/common-fbc.yaml".pathChanged()
+      == "main" && ("pipelines/common-fbc.yaml".pathChanged() || ".tekton/common-pipeline-fbc-pull-request.yaml".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-build-catalog

--- a/.tekton/common-pipeline-mce-2.10-pull-request.yaml
+++ b/.tekton/common-pipeline-mce-2.10-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && "pipelines/common_mce_2.10.yaml".pathChanged()
+      == "main" && ("pipelines/common_mce_2.10.yaml".pathChanged() || ".tekton/common-pipeline-mce-2.10-pull-request.yaml".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-build-catalog

--- a/.tekton/common-pipeline-mce-2.10-pull-request.yaml
+++ b/.tekton/common-pipeline-mce-2.10-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && "pipelines/common_mce_2.10.yaml".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-build-catalog

--- a/.tekton/common-pipeline-mce-2.10-push.yaml
+++ b/.tekton/common-pipeline-mce-2.10-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && "pipelines/common_mce_2.10.yaml".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-build-catalog

--- a/.tekton/common-pipeline-mce-2.10-push.yaml
+++ b/.tekton/common-pipeline-mce-2.10-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && "pipelines/common_mce_2.10.yaml".pathChanged()
+      == "main" && ("pipelines/common_mce_2.10.yaml".pathChanged() || ".tekton/common-pipeline-mce-2.10-push.yaml".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-build-catalog

--- a/.tekton/common-pipeline-oci-ta-pull-request.yaml
+++ b/.tekton/common-pipeline-oci-ta-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && "pipelines/common-oci-ta.yaml".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-build-catalog

--- a/.tekton/common-pipeline-oci-ta-pull-request.yaml
+++ b/.tekton/common-pipeline-oci-ta-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && "pipelines/common-oci-ta.yaml".pathChanged()
+      == "main" && ("pipelines/common-oci-ta.yaml".pathChanged() || ".tekton/common-pipeline-oci-ta-pull-request.yaml".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-build-catalog

--- a/.tekton/common-pipeline-pull-request.yaml
+++ b/.tekton/common-pipeline-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && "pipelines/common.yaml".pathChanged()
+      == "main" && ("pipelines/common.yaml".pathChanged() || ".tekton/common-pipeline-pull-request.yaml".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-build-catalog

--- a/.tekton/common-pipeline-pull-request.yaml
+++ b/.tekton/common-pipeline-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && "pipelines/common.yaml".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-build-catalog

--- a/.tekton/common-pipeline-push.yaml
+++ b/.tekton/common-pipeline-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && "pipelines/common.yaml".pathChanged()
+      == "main" && ("pipelines/common.yaml".pathChanged() || ".tekton/common-pipeline-push.yaml".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-build-catalog

--- a/.tekton/common-pipeline-push.yaml
+++ b/.tekton/common-pipeline-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && "pipelines/common.yaml".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-build-catalog


### PR DESCRIPTION
## Summary

This PR updates all Tekton pipeline CEL expressions in the `.tekton/` directory to only trigger when their corresponding pipeline files in the `pipelines/` directory are modified.

## Changes

- **`.tekton/common-pipeline-fbc-pull-request.yaml`**: Now triggers only when `pipelines/common-fbc.yaml` changes
- **`.tekton/common-pipeline-pull-request.yaml`**: Now triggers only when `pipelines/common.yaml` changes
- **`.tekton/common-pipeline-push.yaml`**: Now triggers only when `pipelines/common.yaml` changes
- **`.tekton/common-pipeline-mce-2.10-pull-request.yaml`**: Now triggers only when `pipelines/common_mce_2.10.yaml` changes
- **`.tekton/common-pipeline-mce-2.10-push.yaml`**: Now triggers only when `pipelines/common_mce_2.10.yaml` changes
- **`.tekton/common-pipeline-oci-ta-pull-request.yaml`**: Now triggers only when `pipelines/common-oci-ta.yaml` changes

## Benefits

- Reduces unnecessary pipeline runs
- Improves CI/CD efficiency
- Each pipeline only runs when its specific configuration changes

## Technical Details

Added `.pathChanged()` conditions to all CEL expressions using the pattern:
```
event == "[pull_request|push]" && target_branch == "main" && "pipelines/[specific-file].yaml".pathChanged()
```

This ensures that each Tekton pipeline is only triggered when its corresponding pipeline definition file is modified.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author