### PR TITLE
Fix: Update clamav-scan task bundle from 0.2 to 0.3

### DIFF
--- a/pipelines/common-oci-ta.yaml
+++ b/pipelines/common-oci-ta.yaml
@@ -371,7 +371,7 @@ spec:
       - name: name
         value: clamav-scan
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:7749146f7e4fe530846f1b15c9366178ec9f44776ef1922a60d3e7e2b8c6426b
+        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:cce2dfcc5bd6e91ee54aacdadad523b013eeae5cdaa7f6a4624b8cbcc040f439
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
## Description

This PR fixes issue #76 by updating the clamav-scan task bundle from version 0.2 to 0.3 in the common-oci-ta.yaml pipeline.

## Changes Made

- Updated `quay.io/konflux-ci/tekton-catalog/task-clamav-scan` from version 0.2 to 0.3
- Updated digest from `sha256:7749146f7e4fe530846f1b15c9366178ec9f44776ef1922a60d3e7e2b8c6426b` to `sha256:cce2dfcc5bd6e91ee54aacdadad523b013eeae5cdaa7f6a4624b8cbcc040f439`

## Benefits of Version 0.3

- **Performance Improvement**: Uses `clamdscan` instead of `clamscan` for parallel scanning (8 threads by default)
- **Multi-architecture Support**: Better support for matrix configurations with separate TaskRuns per architecture
- **Backward Compatibility**: No breaking changes - all existing parameters are preserved with sensible defaults

## Migration Details

According to the [migration documentation](https://github.com/konflux-ci/build-definitions/blob/main/task/clamav-scan/0.3/MIGRATION.md):
- New optional parameters `image-arch` (default: "") and `clamd-max-threads` (default: 8) are added
- No action required from users as the migration is backward compatible
- For multi-arch builds, matrix configuration will be handled automatically by the pipeline migration tool

## Testing

- [x] Verified the task bundle reference and digest are correct
- [x] Confirmed backward compatibility with existing pipeline parameters
- [x] No breaking changes introduced

Fixes #76

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author