### PR TITLE
feat: add Slack notification for Tekton task bundle migration

### DIFF
--- a/.github/workflows/update-tekton-task-bundles.yaml
+++ b/.github/workflows/update-tekton-task-bundles.yaml
@@ -83,6 +83,67 @@ jobs:
           labels: "migration"
           assignees: ${{ github.actor }}
 
+      - name: Send Slack notification for migration
+        if: steps.check_migration.outputs.migration_required == 'true'
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "🚨 Tekton Task Bundle Migration Required",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "🚨 Tekton Task Bundle Migration Required"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Pipeline File:*\n${{ matrix.pipeline_file }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow Run:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "The automated Tekton task bundle update process has detected task bundles that require manual migration. An issue has been created for tracking."
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Workflow Run"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    },
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Repository Issues"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/issues"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
       - name: Fail if migration is required
         run: |
           if jq -e 'length > 0' migration_data.json; then


### PR DESCRIPTION
## Summary

This PR adds Slack notification functionality to the Tekton task bundle update workflow. When migration is required, the workflow will now send a notification to Slack in addition to creating a GitHub issue.

## Changes

- Added a new step 'Send Slack notification for migration' to the workflow
- Uses the official  for notifications
- Implements rich Block Kit formatting with:
  - Alert header with emoji
  - Structured fields showing pipeline file and workflow run ID
  - Descriptive text explaining the migration requirement
  - Action buttons for quick access to workflow run and repository issues
- Notification only triggers when 
- Uses the existing  repository secret

## Testing

The notification step will be triggered automatically when the workflow detects Tekton task bundles that require manual migration. The Slack message provides immediate visibility to the team about required actions.

## Dependencies

- Requires  secret to be configured in the repository (already exists)
- Uses official Slack GitHub Action for reliable delivery