### PR TITLE
Update CODEOWNERS for MCE pipeline files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,14 +9,13 @@
 
 .tekton/common-pipeline-pull-request.yaml @xuezhaojun
 .tekton/common-pipeline-push.yaml @xuezhaojun
-.tekton/common-pipeline-mce-2.10-pull-request.yaml @zhujian7
-.tekton/common-pipeline-mce-2.10-push.yaml @zhujian7
+.tekton/common-pipeline-mce-* @zhujian7 @xuezhaojun
 .tekton/common-pipeline-oci-ta-pull-request.yaml @clyang82
 .tekton/common-pipeline-fbc-pull-request.yaml @clyang82
 
 # Pipeline source files
 pipelines/common.yaml @xuezhaojun
-pipelines/common_mce_2.10.yaml @zhujian7
+pipelines/common_mce_* @zhujian7 @xuezhaojun
 pipelines/common-oci-ta.yaml @clyang82
 pipelines/common-fbc.yaml @clyang82
 


### PR DESCRIPTION
This PR updates the CODEOWNERS file to use wildcard patterns for MCE-related pipeline files.

## Changes
- Use wildcard pattern `.tekton/common-pipeline-mce-*` for all MCE pipeline files in .tekton/
- Use wildcard pattern `pipelines/common_mce_*` for all MCE pipeline files in pipelines/
- Assign ownership to @zhujian7 and @xuezhaojun for all MCE-related files
- Simplify maintenance by using glob patterns instead of individual file entries

## Benefits
- More maintainable: new MCE version files will automatically be covered
- Cleaner configuration: reduced from 10+ lines to 2 lines
- Consistent ownership: all MCE-related files now have the same reviewers

/assign @zhujian7