### PR TITLE
Add jnpacker as project owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # This file defines who needs to review changes to specific files or directories
 
 # Default owners for the entire repository
-* @zhujian7 @xuezhaojun
+* @zhujian7 @xuezhaojun @jnpacker
 
 # Specific ownership for .tekton pipeline files
 # Each file can be assigned to different maintainers for specialized review

--- a/OWNERS
+++ b/OWNERS
@@ -3,9 +3,11 @@ approvers:
 - elgnay
 - xuezhaojun
 - clyang82
+- jnpacker
 
 reviewers:
 - zhujian7
 - elgnay
 - xuezhaojun
 - clyang82
+- jnpacker


### PR DESCRIPTION
This PR adds jnpacker as a project owner by:

- Adding jnpacker to both approvers and reviewers lists in the OWNERS file
- Adding jnpacker to the default owners in .github/CODEOWNERS file

This will grant jnpacker the necessary permissions to review and approve changes across the repository.