### PR TITLE
chore: update CODEOWNERS for pipelines/common.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,8 +7,8 @@
 # Specific ownership for .tekton pipeline files
 # Each file can be assigned to different maintainers for specialized review
 
-.tekton/common-pipeline-pull-request.yaml @xuezhaojun
-.tekton/common-pipeline-push.yaml @xuezhaojun
+.tekton/common-pipeline-pull-request.yaml @clyang82
+.tekton/common-pipeline-push.yaml @clyang82
 .tekton/common-pipeline-mce-* @zhujian7 @xuezhaojun
 .tekton/common-pipeline-oci-ta-pull-request.yaml @clyang82
 .tekton/common-pipeline-fbc-pull-request.yaml @clyang82


### PR DESCRIPTION
## Summary
Transfer ownership of `pipelines/common.yaml` from @xuezhaojun to @clyang82

## Reason
The global hub team is now using this pipeline while server foundation is no longer using it. This ownership change reflects the current usage and ensures appropriate review responsibility.

## Changes
- Updated `.github/CODEOWNERS` to assign `pipelines/common.yaml` to @clyang82

/assign @clyang82

🤖 Generated with [Claude Code](https://claude.ai/code)