### PR TITLE
chore: add MCE_VERSION build arg to common_mce_2.9.yaml

### DIFF
--- a/pipelines/common_mce_2.9.yaml
+++ b/pipelines/common_mce_2.9.yaml
@@ -105,6 +105,9 @@ spec:
         The member id of the slack user, if this is set will mention the user in the slack message; this id can be found in the slack user profile
         by clicking the user profile, in the profile pop-up, click the "More" icon(three dots), and then click "Copy member ID" button. e.g. U0600000000
       type: string
+    - default: "v2.9.1"
+      name: mce-version
+      description: The version of the MCE
   results:
     - description: ""
       name: IMAGE_URL
@@ -220,6 +223,7 @@ spec:
         - name: BUILD_ARGS
           value:
             - $(params.build-args[*])
+            - MCE_VERSION=$(params.mce-version)
         - name: BUILD_ARGS_FILE
           value: $(params.build-args-file)
         - name: PRIVILEGED_NESTED


### PR DESCRIPTION
Add MCE_VERSION="v2.9.1" as default build argument for MCE 2.9 pipeline to ensure proper version information is available during container builds.

How to use it:

https://github.com/stolostron/ocm/blob/backplane-2.9/build/Dockerfile.registration-operator.rhtap

```yaml
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24 AS builder
  WORKDIR /go/src/open-cluster-management.io/ocm
  COPY . .
  ENV GO_PACKAGE open-cluster-management.io/ocm

  RUN GO_BUILD_PACKAGES=./cmd/registration-operator make build --warn-undefined-variables

  FROM registry.access.redhat.com/ubi9/ubi-minimal:latest

  ARG MCE_VERSION # Here!!!
  ENV SOURCE_GIT_TAG=${MCE_VERSION}

  LABEL \
        name="multicluster-engine/registration-operator-rhel9" \
        summary="registration-operator" \
        description="registration-operator" \
        io.k8s.description="registration-operator" \
        io.k8s.display-name="registration-operator" \
        com.redhat.component="multicluster-engine-registration-operator-container" \
        io.openshift.tags="data,images"

  ENV USER_UID=10001

  COPY --from=builder /go/src/open-cluster-management.io/ocm/registration-operator /

  USER ${USER_UID}
```

🤖 Generated with [Claude Code](https://claude.ai/code)