### PR TITLE
feat: add mce-version parameter to MCE pipeline variants

### DIFF
--- a/pipelines/common_mce_2.10.yaml
+++ b/pipelines/common_mce_2.10.yaml
@@ -109,6 +109,10 @@ spec:
         The member id of the slack user, if this is set will mention the user in the slack message; this id can be found in the slack user profile
         by clicking the user profile, in the profile pop-up, click the "More" icon(three dots), and then click "Copy member ID" button. e.g. U0600000000
       type: string
+    - default: "v2.10.0"
+      description: The version of the MCE
+      name: mce-version
+      type: string
   results:
     - description: ""
       name: IMAGE_URL
@@ -226,6 +230,7 @@ spec:
         - name: BUILD_ARGS
           value:
             - $(params.build-args[*])
+            - MCE_VERSION=$(params.mce-version)
         - name: BUILD_ARGS_FILE
           value: $(params.build-args-file)
         - name: PRIVILEGED_NESTED

--- a/pipelines/common_mce_2.6.yaml
+++ b/pipelines/common_mce_2.6.yaml
@@ -109,6 +109,10 @@ spec:
         The member id of the slack user, if this is set will mention the user in the slack message; this id can be found in the slack user profile
         by clicking the user profile, in the profile pop-up, click the "More" icon(three dots), and then click "Copy member ID" button. e.g. U0600000000
       type: string
+    - default: "v2.6.8"
+      description: The version of the MCE
+      name: mce-version
+      type: string
   results:
     - description: ""
       name: IMAGE_URL
@@ -226,6 +230,7 @@ spec:
         - name: BUILD_ARGS
           value:
             - $(params.build-args[*])
+            - MCE_VERSION=$(params.mce-version)
         - name: BUILD_ARGS_FILE
           value: $(params.build-args-file)
         - name: PRIVILEGED_NESTED

--- a/pipelines/common_mce_2.7.yaml
+++ b/pipelines/common_mce_2.7.yaml
@@ -109,6 +109,10 @@ spec:
         The member id of the slack user, if this is set will mention the user in the slack message; this id can be found in the slack user profile
         by clicking the user profile, in the profile pop-up, click the "More" icon(three dots), and then click "Copy member ID" button. e.g. U0600000000
       type: string
+    - default: "2.7.6"
+      description: The version of the MCE
+      name: mce-version
+      type: string
   results:
     - description: ""
       name: IMAGE_URL
@@ -226,6 +230,7 @@ spec:
         - name: BUILD_ARGS
           value:
             - $(params.build-args[*])
+            - MCE_VERSION=$(params.mce-version)
         - name: BUILD_ARGS_FILE
           value: $(params.build-args-file)
         - name: PRIVILEGED_NESTED

--- a/pipelines/common_mce_2.8.yaml
+++ b/pipelines/common_mce_2.8.yaml
@@ -109,6 +109,10 @@ spec:
         The member id of the slack user, if this is set will mention the user in the slack message; this id can be found in the slack user profile
         by clicking the user profile, in the profile pop-up, click the "More" icon(three dots), and then click "Copy member ID" button. e.g. U0600000000
       type: string
+    - default: "v2.8.3"
+      description: The version of the MCE
+      name: mce-version
+      type: string
   results:
     - description: ""
       name: IMAGE_URL
@@ -226,6 +230,7 @@ spec:
         - name: BUILD_ARGS
           value:
             - $(params.build-args[*])
+            - MCE_VERSION=$(params.mce-version)
         - name: BUILD_ARGS_FILE
           value: $(params.build-args-file)
         - name: PRIVILEGED_NESTED


### PR DESCRIPTION
## Summary
- Add `mce-version` parameter to MCE-specific pipeline files (2.6, 2.7, 2.8, 2.10)
- Include MCE_VERSION build argument in container build process
- Align with existing pattern from common_mce_2.9.yaml

## Changes
- **pipelines/common_mce_2.6.yaml**: Add mce-version parameter with default "v2.6.8"
- **pipelines/common_mce_2.7.yaml**: Add mce-version parameter with default "2.7.6"  
- **pipelines/common_mce_2.8.yaml**: Add mce-version parameter with default "v2.8.3"
- **pipelines/common_mce_2.10.yaml**: Add mce-version parameter with default "v2.10.0"

Each pipeline now passes `MCE_VERSION=$(params.mce-version)` in BUILD_ARGS to ensure proper version information is available during container builds.

## Test plan
- [ ] Verify YAML syntax is valid for all modified files
- [ ] Confirm pipeline parameters are correctly defined
- [ ] Test that BUILD_ARGS properly includes MCE_VERSION
- [ ] Validate pipelines can be referenced without errors

🤖 Generated with [Claude Code](https://claude.ai/code)