### PR TITLE
Instantiate common MintMaker configs

### DIFF
--- a/mintmaker/README.md
+++ b/mintmaker/README.md
@@ -1,0 +1,12 @@
+# MintMaker extensible configurations
+
+You can use these configurations in your repositories by using the `extends` key in your
+`renovate.json` configuration. Replace the `mintmaker/<file>` with the file from which you'd like 
+to extend your configuration (without the `.json` extension):
+
+```json
+"extends": ["github>stolostron/konflux-build-catalog//mintmaker/default"]
+```
+
+Documentation:
+- [Renovate Presets](https://docs.renovatebot.com/config-presets/#github-hosted-presets)

--- a/mintmaker/default.json
+++ b/mintmaker/default.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dockerfile": {
+    "managerFilePatterns": ["Dockerfile.rhtap"],
+    "pinDigests": true
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true
+}

--- a/mintmaker/gomod_security_only.json
+++ b/mintmaker/gomod_security_only.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>stolostron/konflux-build-catalog//mintmaker/default"],
+  "gomod": {
+    "packageRules": [
+      {
+        "matchDepTypes": ["indirect"],
+        "enabled": false
+      }
+    ]
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "enabled": false,
+      "vulnerabilityAlerts": {
+        "enabled": true
+      },
+      "osvVulnerabilityAlerts": true
+    }
+  ]
+}


### PR DESCRIPTION
This puts some common MintMaker configs in place that I've found to be effective so far. Having configs that build from one another give squads different configuration foundations from which to build their own.

The `default` config establishes digest pinning, which is essential for rebuilding images now that the common pipeline is in place, and also enables vulnerability updates globally for all managers.

The `gomod_security_only` builds on the `default` and disables all but vulnerability updates for the `gomod` manager.

Slack thread: https://redhat-internal.slack.com/archives/C06TJJ3E0MU/p1756222298847909