### PR TITLE
Add MCE_VERSION build arg and SOURCE_GIT_TAG environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ LABEL \
       io.openshift.tags="data,images" \
       version="1.0.0"
 
+ARG MCE_VERSION
+ENV SOURCE_GIT_TAG=${MCE_VERSION}
+RUN echo "SOURCE_GIT_TAG=${SOURCE_GIT_TAG}"
+
 # Copy pipeline files to demonstrate this is a pipeline catalog
 COPY pipelines/ /pipelines/
 COPY .tekton/ /.tekton/


### PR DESCRIPTION
## Summary
- Add MCE_VERSION build argument to Dockerfile to support version-specific builds
- Set SOURCE_GIT_TAG environment variable from MCE_VERSION for traceability
- Add echo statement to log the SOURCE_GIT_TAG value during container build

## Test plan
- [ ] Verify Dockerfile builds successfully with MCE_VERSION argument
- [ ] Confirm SOURCE_GIT_TAG environment variable is set correctly
- [ ] Test that echo statement outputs the expected value during build

🤖 Generated with [Claude Code](https://claude.ai/code)