### PR TITLE
Update MCE version default to include v prefix in common_mce_2.7.yaml

### DIFF
--- a/pipelines/common_mce_2.7.yaml
+++ b/pipelines/common_mce_2.7.yaml
@@ -109,7 +109,7 @@ spec:
         The member id of the slack user, if this is set will mention the user in the slack message; this id can be found in the slack user profile
         by clicking the user profile, in the profile pop-up, click the "More" icon(three dots), and then click "Copy member ID" button. e.g. U0600000000
       type: string
-    - default: "2.7.6"
+    - default: "v2.7.6"
       description: The version of the MCE
       name: mce-version
       type: string


### PR DESCRIPTION
## Summary
- Update default mce-version parameter from '2.7.6' to 'v2.7.6' in common_mce_2.7.yaml
- Ensures consistency with semantic versioning format across pipeline configurations

## Changes
- Modified the default value for the `mce-version` parameter to include the "v" prefix
- This aligns with standard semantic versioning practices and consistency with other MCE pipeline versions

## Test plan
- [ ] Verify pipeline validates successfully with the updated default value
- [ ] Confirm the change doesn't break existing pipeline runs
- [ ] Test that the version parameter works correctly with the new default format

🤖 Generated with [Claude Code](https://claude.ai/code)