### PR TITLE
Set param defaults and make `run-opm-commands` optional

### DIFF
--- a/pipelines/common-fbc.yaml
+++ b/pipelines/common-fbc.yaml
@@ -86,10 +86,12 @@ spec:
       set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms
     type: array
-  - description: An array of arguments passed to opm when executed.
+  - default: []
+    description: An array of arguments passed to opm when executed.
     name: opm-args
     type: array
-  - description: The path where the output from opm will be stored (i.e., where catalog.json will be saved).
+  - default: ""
+    description: The path where the output from opm will be stored (i.e., where catalog.json will be saved).
     name: opm-output-path
     type: string
   - default: ""


### PR DESCRIPTION
This will let the opm args be optional.

>[User error] PipelineRun is missing some parameters required by Pipeline: pipelineRun missing parameters: [opm-args opm-output-path] 

Followup to:
- #148