### PR TITLE
CNTRLPLANE-1396: feat(konflux): tag MCE HO images with latest

### DIFF
--- a/pipelines/common_mce_2.10.yaml
+++ b/pipelines/common_mce_2.10.yaml
@@ -557,6 +557,9 @@ spec:
           value: $(tasks.build-image-index.results.IMAGE_URL)
         - name: IMAGE_DIGEST
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: ADDITIONAL_TAGS
+          value:
+            - 'latest'
       runAfter:
         - build-image-index
       taskRef:

--- a/pipelines/common_mce_2.6.yaml
+++ b/pipelines/common_mce_2.6.yaml
@@ -557,6 +557,9 @@ spec:
           value: $(tasks.build-image-index.results.IMAGE_URL)
         - name: IMAGE_DIGEST
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: ADDITIONAL_TAGS
+          value:
+            - 'latest'
       runAfter:
         - build-image-index
       taskRef:

--- a/pipelines/common_mce_2.7.yaml
+++ b/pipelines/common_mce_2.7.yaml
@@ -557,6 +557,9 @@ spec:
           value: $(tasks.build-image-index.results.IMAGE_URL)
         - name: IMAGE_DIGEST
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: ADDITIONAL_TAGS
+          value:
+            - 'latest'
       runAfter:
         - build-image-index
       taskRef:

--- a/pipelines/common_mce_2.8.yaml
+++ b/pipelines/common_mce_2.8.yaml
@@ -557,6 +557,9 @@ spec:
           value: $(tasks.build-image-index.results.IMAGE_URL)
         - name: IMAGE_DIGEST
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: ADDITIONAL_TAGS
+          value:
+            - 'latest'
       runAfter:
         - build-image-index
       taskRef:

--- a/pipelines/common_mce_2.9.yaml
+++ b/pipelines/common_mce_2.9.yaml
@@ -556,6 +556,9 @@ spec:
           value: $(tasks.build-image-index.results.IMAGE_URL)
         - name: IMAGE_DIGEST
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: ADDITIONAL_TAGS
+          value:
+            - 'latest'
       runAfter:
         - build-image-index
       taskRef:


### PR DESCRIPTION
In order to simplify Multi Cluster Engine HyperShift Operator image discovery in Quality Engineering verification, let's tag the built images in Konflux so it is always evident which is the latest build.