### PR TITLE
Fix: migrate task-buildah-remote-oci-ta from 0.4 to 0.5

### DIFF
--- a/pipelines/common-fbc.yaml
+++ b/pipelines/common-fbc.yaml
@@ -249,7 +249,7 @@ spec:
       - name: name
         value: buildah-remote-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:7ff1a2e486924478e7724005464d60dab9a85e2ae4734818057ece3845797509
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:312a42ce2fe4b59fb9bdd5ee227e05fdff22a2346bc3c9c0ec62d2b0214a2788
       - name: kind
         value: task
       resolver: bundles

--- a/pipelines/common.yaml
+++ b/pipelines/common.yaml
@@ -248,7 +248,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:7ff1a2e486924478e7724005464d60dab9a85e2ae4734818057ece3845797509
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:312a42ce2fe4b59fb9bdd5ee227e05fdff22a2346bc3c9c0ec62d2b0214a2788
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common_mce_2.10.yaml
+++ b/pipelines/common_mce_2.10.yaml
@@ -248,7 +248,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:7ff1a2e486924478e7724005464d60dab9a85e2ae4734818057ece3845797509
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:312a42ce2fe4b59fb9bdd5ee227e05fdff22a2346bc3c9c0ec62d2b0214a2788
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common_mce_2.6.yaml
+++ b/pipelines/common_mce_2.6.yaml
@@ -248,7 +248,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:7ff1a2e486924478e7724005464d60dab9a85e2ae4734818057ece3845797509
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:312a42ce2fe4b59fb9bdd5ee227e05fdff22a2346bc3c9c0ec62d2b0214a2788
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common_mce_2.7.yaml
+++ b/pipelines/common_mce_2.7.yaml
@@ -248,7 +248,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:7ff1a2e486924478e7724005464d60dab9a85e2ae4734818057ece3845797509
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:312a42ce2fe4b59fb9bdd5ee227e05fdff22a2346bc3c9c0ec62d2b0214a2788
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common_mce_2.8.yaml
+++ b/pipelines/common_mce_2.8.yaml
@@ -248,7 +248,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:7ff1a2e486924478e7724005464d60dab9a85e2ae4734818057ece3845797509
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:312a42ce2fe4b59fb9bdd5ee227e05fdff22a2346bc3c9c0ec62d2b0214a2788
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common_mce_2.9.yaml
+++ b/pipelines/common_mce_2.9.yaml
@@ -247,7 +247,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:7ff1a2e486924478e7724005464d60dab9a85e2ae4734818057ece3845797509
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:312a42ce2fe4b59fb9bdd5ee227e05fdff22a2346bc3c9c0ec62d2b0214a2788
           - name: kind
             value: task
         resolver: bundles


### PR DESCRIPTION
## Summary
Migrate the `task-buildah-remote-oci-ta` Tekton task bundle from version 0.4 to 0.5 across all pipeline files to fix a regression where SBOMs did not include dependencies identified by Hermeto.

## Changes
- Updated `task-buildah-remote-oci-ta` from `0.4@sha256:7ff1a2e...` to `0.5@sha256:312a42c...` in all pipeline files:
  - `pipelines/common.yaml`
  - `pipelines/common-fbc.yaml`
  - `pipelines/common_mce_2.6.yaml`
  - `pipelines/common_mce_2.7.yaml`
  - `pipelines/common_mce_2.8.yaml`
  - `pipelines/common_mce_2.9.yaml`
  - `pipelines/common_mce_2.10.yaml`

## Migration Details
Version 0.5 fixes a regression where the SBOMs did not include the dependencies identified by Hermeto (from the prefetch task), making the SBOMs less accurate. According to the migration documentation, no manual configuration changes are required.

## Test plan
- [x] Verified YAML syntax is valid for all updated pipeline files
- [x] Confirmed all 7 pipeline files have been updated consistently
- [x] Reviewed migration documentation to ensure no breaking changes

Fixes #301

🤖 Generated with [Claude Code](https://claude.ai/code)