### PR TITLE
Fix: migrate task-buildah-oci-ta from 0.4 to 0.5

### DIFF
--- a/pipelines/common-oci-ta.yaml
+++ b/pipelines/common-oci-ta.yaml
@@ -200,7 +200,7 @@ spec:
       - name: name
         value: buildah-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:820e397596f9816c953e16328afa496337a2ede6b457fe600a40d44ebca5a16f
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.5@sha256:e24c062961fd8c200e2d1e08393e0c347f1b42141f2b76f28b5145b6c5bbb27a
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
## Summary
- Updated task-buildah-oci-ta from version 0.4 to 0.5 in pipelines/common-oci-ta.yaml
- Fixes SBOM accuracy issue where dependencies from prefetch task were not included

## Details
Version 0.5 of task-buildah-oci-ta fixes a regression where the SBOMs did not include the dependencies identified by Hermeto (from the prefetch task), making the SBOMs less accurate. This update improves SBOM accuracy with no breaking changes.

## Test plan
- [x] YAML syntax validation passed
- [x] Migration documentation reviewed - no action required from users
- [ ] Automated pipeline validation will run via .tekton/ configurations

Fixes #296

🤖 Generated with [Claude Code](https://claude.ai/code)