### PR TITLE
chore: add signoff to automated PR commits

### DIFF
--- a/.github/workflows/update-tekton-task-bundles.yaml
+++ b/.github/workflows/update-tekton-task-bundles.yaml
@@ -172,5 +172,6 @@ jobs:
           branch: tekton-bundle-update-${{ matrix.pipeline_file }}
           base: main
           add-paths: pipelines/${{ matrix.pipeline_file }}
+          signoff: true
           labels: |
             automated-update


### PR DESCRIPTION
## Summary
- Add `signoff: true` parameter to the `peter-evans/create-pull-request` action in the update-tekton-task-bundles workflow
- This ensures all commits created by github-actions bot are properly signed off

## Background
Previously, PRs created by the github-actions bot were missing the required signoff on commits. This change fixes that by configuring the create-pull-request action to automatically add the `--signoff` flag when creating commits.

## Changes
- Updated `.github/workflows/update-tekton-task-bundles.yaml` to include `signoff: true` parameter

🤖 Generated with [Claude Code](https://claude.ai/code)