### PR TITLE
Migrate buildah task bundles from 0.5 to 0.6

### DIFF
--- a/pipelines/common-fbc.yaml
+++ b/pipelines/common-fbc.yaml
@@ -313,7 +313,7 @@ spec:
       - name: name
         value: buildah-remote-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:f9f413d67e46ec348f0075cff1b2548f9d2d02e7e58cfaffe429a75121a12fd1
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.6@sha256:ac05dabe8b6b446f974cf2b6ef1079cfaa9443d7078c2ebe3ec79aa650e1b5b2
       - name: kind
         value: task
       resolver: bundles

--- a/pipelines/common-oci-ta.yaml
+++ b/pipelines/common-oci-ta.yaml
@@ -270,7 +270,7 @@ spec:
           - name: name
             value: buildah-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.5@sha256:fb3b36f1f800960dd3eb6291c9f8802b7305608a61b27310a541f53a716844a3
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.6@sha256:7b4c101b71e48b267079a5b6331d22de0b25e008c9e1dcaca1c41c4312391e39
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common.yaml
+++ b/pipelines/common.yaml
@@ -258,7 +258,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:f9f413d67e46ec348f0075cff1b2548f9d2d02e7e58cfaffe429a75121a12fd1
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.6@sha256:ac05dabe8b6b446f974cf2b6ef1079cfaa9443d7078c2ebe3ec79aa650e1b5b2
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common_mce_2.10.yaml
+++ b/pipelines/common_mce_2.10.yaml
@@ -258,7 +258,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:f9f413d67e46ec348f0075cff1b2548f9d2d02e7e58cfaffe429a75121a12fd1
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.6@sha256:ac05dabe8b6b446f974cf2b6ef1079cfaa9443d7078c2ebe3ec79aa650e1b5b2
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common_mce_2.6.yaml
+++ b/pipelines/common_mce_2.6.yaml
@@ -258,7 +258,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:f9f413d67e46ec348f0075cff1b2548f9d2d02e7e58cfaffe429a75121a12fd1
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.6@sha256:ac05dabe8b6b446f974cf2b6ef1079cfaa9443d7078c2ebe3ec79aa650e1b5b2
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common_mce_2.7.yaml
+++ b/pipelines/common_mce_2.7.yaml
@@ -258,7 +258,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:f9f413d67e46ec348f0075cff1b2548f9d2d02e7e58cfaffe429a75121a12fd1
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.6@sha256:ac05dabe8b6b446f974cf2b6ef1079cfaa9443d7078c2ebe3ec79aa650e1b5b2
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common_mce_2.8.yaml
+++ b/pipelines/common_mce_2.8.yaml
@@ -258,7 +258,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:f9f413d67e46ec348f0075cff1b2548f9d2d02e7e58cfaffe429a75121a12fd1
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.6@sha256:ac05dabe8b6b446f974cf2b6ef1079cfaa9443d7078c2ebe3ec79aa650e1b5b2
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common_mce_2.9.yaml
+++ b/pipelines/common_mce_2.9.yaml
@@ -257,7 +257,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:f9f413d67e46ec348f0075cff1b2548f9d2d02e7e58cfaffe429a75121a12fd1
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.6@sha256:ac05dabe8b6b446f974cf2b6ef1079cfaa9443d7078c2ebe3ec79aa650e1b5b2
           - name: kind
             value: task
         resolver: bundles


### PR DESCRIPTION
## Summary

This PR migrates all pipeline files to use buildah task bundles version 0.6, which introduces the **Contextual SBOM feature** for SPDX SBOM format. This is a backwards-compatible change that requires no pipeline configuration updates.

## Changes

### Updated task-buildah-remote-oci-ta from 0.5 to 0.6:
- [pipelines/common.yaml](pipelines/common.yaml)
- [pipelines/common-fbc.yaml](pipelines/common-fbc.yaml)
- [pipelines/common_mce_2.6.yaml](pipelines/common_mce_2.6.yaml)
- [pipelines/common_mce_2.7.yaml](pipelines/common_mce_2.7.yaml)
- [pipelines/common_mce_2.8.yaml](pipelines/common_mce_2.8.yaml)
- [pipelines/common_mce_2.9.yaml](pipelines/common_mce_2.9.yaml)
- [pipelines/common_mce_2.10.yaml](pipelines/common_mce_2.10.yaml)

### Updated task-buildah-oci-ta from 0.5 to 0.6:
- [pipelines/common-oci-ta.yaml](pipelines/common-oci-ta.yaml)

## Migration Notes

Per the [upstream migration documentation](https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-remote-oci-ta/0.6/MIGRATION.md):
- No specific migration action required
- Contextual SBOM will be produced by default when requirements are met
- Legacy SBOM (non-contextualized) will be produced if requirements not met
- If issues arise, the `CONTEXTUALIZE_SBOM` parameter can be set to `false` to disable the feature

## What is Contextual SBOM?

Contextual SBOM establishes relationships between container images and their parent (base) or builder images in the software supply chain. Instead of treating each image as isolated, it creates a hierarchical view showing how packages flow from parent or builder images to child images.

## Test Plan

- [x] All YAML files validated successfully
- [ ] Automated tests will run via `.tekton/` configurations
- [ ] Verify builds complete successfully
- [ ] Verify SBOM generation works as expected

## Related Issues

Fixes #426
Fixes #427
Fixes #428
Fixes #429
Fixes #430
Fixes #431
Fixes #432
Fixes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)