### PR TITLE
add group id

### DIFF
--- a/pipelines/common.yaml
+++ b/pipelines/common.yaml
@@ -116,6 +116,11 @@ spec:
         The member id of the slack user, if this is set will mention the user in the slack message; this id can be found in the slack user profile
         by clicking the user profile, in the profile pop-up, click the "More" icon(three dots), and then click "Copy member ID" button. e.g. U0600000000
       type: string
+    - default: ""
+      name: slack-group-id
+      description: |
+        The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
+      type: string
     - name: buildah-format
       default: docker
       type: string
@@ -645,7 +650,7 @@ spec:
       params:
         - name: message
           value: |
-            :bangbang: <@$(params.slack-member-id)> PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
+            :bangbang: PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
             - git source: $(params.git-url)/commit/$(params.revision)
             - output image: $(params.output-image)
             - see details: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/$(context.pipelineRun.namespace)/applications/$(params.konflux-application-name)/pipelineruns/$(context.pipelineRun.name)
@@ -653,15 +658,68 @@ spec:
           value: $(params.slack-webhook-url-secret-name)
         - name: key-name
           value: $(params.slack-webhook-url-secret-key)
-      taskRef:
+        - name: slack-member-id
+          value: $(params.slack-member-id)
+        - name: slack-group-id
+          value: $(params.slack-group-id)
+      taskSpec:
         params:
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:4e68fe2225debc256d403b828ed358345bb56d03327b46d55cb6c42911375750
-          - name: name
-            value: slack-webhook-notification
-          - name: kind
-            value: Task
-        resolver: bundles
+          - name: message
+            type: string
+            description: The message to send to Slack
+          - name: secret-name
+            type: string
+            description: The name of the secret containing the webhook URL
+          - name: key-name
+            type: string
+            description: The key in the secret containing the webhook URL
+          - name: slack-member-id
+            type: string
+            default: ""
+            description: Slack member ID to mention (e.g., U0600000000)
+          - name: slack-group-id
+            type: string
+            default: ""
+            description: Slack group ID to mention (e.g., S07XXXXXXXX for usergroups)
+        steps:
+          - name: post-to-slack
+            image: registry.redhat.io/ubi9/ubi-minimal:latest
+            env:
+              - name: SLACK_WEBHOOK_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: $(params.secret-name)
+                    key: $(params.key-name)
+            script: |
+              #!/bin/bash
+              set -e
+
+              # Base message
+              MESSAGE="$(params.message)"
+
+              # Add mention for member ID if provided
+              if [ -n "$(params.slack-member-id)" ]; then
+                # Slack user mention format: <@USER_ID>
+                MENTION="<@$(params.slack-member-id)>"
+                MESSAGE="${MENTION} ${MESSAGE}"
+              fi
+
+              # Add mention for group ID if provided
+              if [ -n "$(params.slack-group-id)" ]; then
+                # Slack group mention format: <!subteam^GROUP_ID>
+                GROUP_MENTION="<!subteam^$(params.slack-group-id)>"
+                MESSAGE="${GROUP_MENTION} ${MESSAGE}"
+              fi
+
+              # Escape quotes and newlines for JSON
+              MESSAGE_JSON=$(echo "$MESSAGE" | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')
+
+              # Send to Slack
+              curl -X POST "$SLACK_WEBHOOK_URL" \
+                -H 'Content-Type: application/json' \
+                -d "{\"text\": \"$MESSAGE_JSON\"}"
+
+              echo "Slack notification sent successfully"
       when:
         - input: $(tasks.status)
           operator: in


### PR DESCRIPTION
used to add group id so that when send the slack message, it can let the group knows about the build status.