### PR TITLE
Add slack-group-id parameter to all pipeline files

### DIFF
--- a/pipelines/common-fbc.yaml
+++ b/pipelines/common-fbc.yaml
@@ -26,7 +26,7 @@ spec:
     params:
       - name: message
         value: |
-          :bangbang: <@$(params.slack-member-id)> PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
+          :bangbang: PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
           - git source: $(params.git-url)/commit/$(params.revision)
           - output image: $(params.output-image)
           - see details: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/$(context.pipelineRun.namespace)/applications/$(params.konflux-application-name)/pipelineruns/$(context.pipelineRun.name)
@@ -34,10 +34,16 @@ spec:
         value: $(params.slack-webhook-url-secret-name)
       - name: key-name
         value: $(params.slack-webhook-url-secret-key)
+      - name: user-ids
+        value:
+          - $(params.slack-member-id)
+      - name: group-ids
+        value:
+          - $(params.slack-group-id)
     taskRef:
       params:
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:4e68fe2225debc256d403b828ed358345bb56d03327b46d55cb6c42911375750
+        value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:f81bd9de5ab2984556cbacf7ffcce91f91b03521f8644e54d47c18898c100306
       - name: name
         value: slack-webhook-notification
       - name: kind
@@ -162,6 +168,10 @@ spec:
       The member id of the slack user, if this is set will mention the user in the slack message; this id can be found in the slack user profile
       by clicking the user profile, in the profile pop-up, click the "More" icon(three dots), and then click "Copy member ID" button. e.g. U0600000000
     type: string
+  - default: ""
+    name: slack-group-id
+    description: |
+      The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
   results:
   - description: ""
     name: IMAGE_URL

--- a/pipelines/common-oci-ta.yaml
+++ b/pipelines/common-oci-ta.yaml
@@ -26,7 +26,7 @@ spec:
       params:
         - name: message
           value: |
-            :bangbang: <@$(params.slack-member-id)> PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
+            :bangbang: PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
             - git source: $(params.git-url)/commit/$(params.revision)
             - output image: $(params.output-image)
             - see details: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/$(context.pipelineRun.namespace)/applications/$(params.konflux-application-name)/pipelineruns/$(context.pipelineRun.name)
@@ -34,10 +34,16 @@ spec:
           value: $(params.slack-webhook-url-secret-name)
         - name: key-name
           value: $(params.slack-webhook-url-secret-key)
+        - name: user-ids
+          value:
+            - $(params.slack-member-id)
+        - name: group-ids
+          value:
+            - $(params.slack-group-id)
       taskRef:
         params:
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:4e68fe2225debc256d403b828ed358345bb56d03327b46d55cb6c42911375750
+            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:f81bd9de5ab2984556cbacf7ffcce91f91b03521f8644e54d47c18898c100306
           - name: name
             value: slack-webhook-notification
           - name: kind
@@ -144,6 +150,10 @@ spec:
         The member id of the slack user, if this is set will mention the user in the slack message; this id can be found in the slack user profile
         by clicking the user profile, in the profile pop-up, click the "More" icon(three dots), and then click "Copy member ID" button. e.g. U0600000000
       type: string
+    - default: ""
+      name: slack-group-id
+      description: |
+        The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
     - name: buildah-format
       default: docker
       type: string

--- a/pipelines/common.yaml
+++ b/pipelines/common.yaml
@@ -116,6 +116,10 @@ spec:
         The member id of the slack user, if this is set will mention the user in the slack message; this id can be found in the slack user profile
         by clicking the user profile, in the profile pop-up, click the "More" icon(three dots), and then click "Copy member ID" button. e.g. U0600000000
       type: string
+    - default: ""
+      name: slack-group-id
+      description: |
+        The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
     - name: buildah-format
       default: docker
       type: string
@@ -645,7 +649,7 @@ spec:
       params:
         - name: message
           value: |
-            :bangbang: <@$(params.slack-member-id)> PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
+            :bangbang: PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
             - git source: $(params.git-url)/commit/$(params.revision)
             - output image: $(params.output-image)
             - see details: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/$(context.pipelineRun.namespace)/applications/$(params.konflux-application-name)/pipelineruns/$(context.pipelineRun.name)
@@ -653,10 +657,16 @@ spec:
           value: $(params.slack-webhook-url-secret-name)
         - name: key-name
           value: $(params.slack-webhook-url-secret-key)
+        - name: user-ids
+          value:
+            - $(params.slack-member-id)
+        - name: group-ids
+          value:
+            - $(params.slack-group-id)
       taskRef:
         params:
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:4e68fe2225debc256d403b828ed358345bb56d03327b46d55cb6c42911375750
+            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:f81bd9de5ab2984556cbacf7ffcce91f91b03521f8644e54d47c18898c100306
           - name: name
             value: slack-webhook-notification
           - name: kind

--- a/pipelines/common_mce_2.10.yaml
+++ b/pipelines/common_mce_2.10.yaml
@@ -113,6 +113,10 @@ spec:
         The member id of the slack user, if this is set will mention the user in the slack message; this id can be found in the slack user profile
         by clicking the user profile, in the profile pop-up, click the "More" icon(three dots), and then click "Copy member ID" button. e.g. U0600000000
       type: string
+    - default: ""
+      name: slack-group-id
+      description: |
+        The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
     - default: "v2.10.0"
       description: The version of the MCE
       name: mce-version
@@ -645,7 +649,7 @@ spec:
       params:
         - name: message
           value: |
-            :bangbang: <@$(params.slack-member-id)> PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
+            :bangbang: PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
             - git source: $(params.git-url)/commit/$(params.revision)
             - output image: $(params.output-image)
             - see details: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/$(context.pipelineRun.namespace)/applications/$(params.konflux-application-name)/pipelineruns/$(context.pipelineRun.name)
@@ -653,10 +657,16 @@ spec:
           value: $(params.slack-webhook-url-secret-name)
         - name: key-name
           value: $(params.slack-webhook-url-secret-key)
+        - name: user-ids
+          value:
+            - $(params.slack-member-id)
+        - name: group-ids
+          value:
+            - $(params.slack-group-id)
       taskRef:
         params:
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:4e68fe2225debc256d403b828ed358345bb56d03327b46d55cb6c42911375750
+            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:f81bd9de5ab2984556cbacf7ffcce91f91b03521f8644e54d47c18898c100306
           - name: name
             value: slack-webhook-notification
           - name: kind

--- a/pipelines/common_mce_2.6.yaml
+++ b/pipelines/common_mce_2.6.yaml
@@ -113,6 +113,10 @@ spec:
         The member id of the slack user, if this is set will mention the user in the slack message; this id can be found in the slack user profile
         by clicking the user profile, in the profile pop-up, click the "More" icon(three dots), and then click "Copy member ID" button. e.g. U0600000000
       type: string
+    - default: ""
+      name: slack-group-id
+      description: |
+        The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
     - default: "v2.6.8"
       description: The version of the MCE
       name: mce-version
@@ -645,7 +649,7 @@ spec:
       params:
         - name: message
           value: |
-            :bangbang: <@$(params.slack-member-id)> PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
+            :bangbang: PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
             - git source: $(params.git-url)/commit/$(params.revision)
             - output image: $(params.output-image)
             - see details: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/$(context.pipelineRun.namespace)/applications/$(params.konflux-application-name)/pipelineruns/$(context.pipelineRun.name)
@@ -653,10 +657,16 @@ spec:
           value: $(params.slack-webhook-url-secret-name)
         - name: key-name
           value: $(params.slack-webhook-url-secret-key)
+        - name: user-ids
+          value:
+            - $(params.slack-member-id)
+        - name: group-ids
+          value:
+            - $(params.slack-group-id)
       taskRef:
         params:
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:4e68fe2225debc256d403b828ed358345bb56d03327b46d55cb6c42911375750
+            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:f81bd9de5ab2984556cbacf7ffcce91f91b03521f8644e54d47c18898c100306
           - name: name
             value: slack-webhook-notification
           - name: kind

--- a/pipelines/common_mce_2.7.yaml
+++ b/pipelines/common_mce_2.7.yaml
@@ -113,6 +113,10 @@ spec:
         The member id of the slack user, if this is set will mention the user in the slack message; this id can be found in the slack user profile
         by clicking the user profile, in the profile pop-up, click the "More" icon(three dots), and then click "Copy member ID" button. e.g. U0600000000
       type: string
+    - default: ""
+      name: slack-group-id
+      description: |
+        The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
     - default: "v2.7.6"
       description: The version of the MCE
       name: mce-version
@@ -645,7 +649,7 @@ spec:
       params:
         - name: message
           value: |
-            :bangbang: <@$(params.slack-member-id)> PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
+            :bangbang: PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
             - git source: $(params.git-url)/commit/$(params.revision)
             - output image: $(params.output-image)
             - see details: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/$(context.pipelineRun.namespace)/applications/$(params.konflux-application-name)/pipelineruns/$(context.pipelineRun.name)
@@ -653,10 +657,16 @@ spec:
           value: $(params.slack-webhook-url-secret-name)
         - name: key-name
           value: $(params.slack-webhook-url-secret-key)
+        - name: user-ids
+          value:
+            - $(params.slack-member-id)
+        - name: group-ids
+          value:
+            - $(params.slack-group-id)
       taskRef:
         params:
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:4e68fe2225debc256d403b828ed358345bb56d03327b46d55cb6c42911375750
+            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:f81bd9de5ab2984556cbacf7ffcce91f91b03521f8644e54d47c18898c100306
           - name: name
             value: slack-webhook-notification
           - name: kind

--- a/pipelines/common_mce_2.8.yaml
+++ b/pipelines/common_mce_2.8.yaml
@@ -113,6 +113,10 @@ spec:
         The member id of the slack user, if this is set will mention the user in the slack message; this id can be found in the slack user profile
         by clicking the user profile, in the profile pop-up, click the "More" icon(three dots), and then click "Copy member ID" button. e.g. U0600000000
       type: string
+    - default: ""
+      name: slack-group-id
+      description: |
+        The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
     - default: "v2.8.3"
       description: The version of the MCE
       name: mce-version
@@ -645,7 +649,7 @@ spec:
       params:
         - name: message
           value: |
-            :bangbang: <@$(params.slack-member-id)> PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
+            :bangbang: PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
             - git source: $(params.git-url)/commit/$(params.revision)
             - output image: $(params.output-image)
             - see details: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/$(context.pipelineRun.namespace)/applications/$(params.konflux-application-name)/pipelineruns/$(context.pipelineRun.name)
@@ -653,10 +657,16 @@ spec:
           value: $(params.slack-webhook-url-secret-name)
         - name: key-name
           value: $(params.slack-webhook-url-secret-key)
+        - name: user-ids
+          value:
+            - $(params.slack-member-id)
+        - name: group-ids
+          value:
+            - $(params.slack-group-id)
       taskRef:
         params:
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:4e68fe2225debc256d403b828ed358345bb56d03327b46d55cb6c42911375750
+            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:f81bd9de5ab2984556cbacf7ffcce91f91b03521f8644e54d47c18898c100306
           - name: name
             value: slack-webhook-notification
           - name: kind

--- a/pipelines/common_mce_2.9.yaml
+++ b/pipelines/common_mce_2.9.yaml
@@ -113,6 +113,10 @@ spec:
         The member id of the slack user, if this is set will mention the user in the slack message; this id can be found in the slack user profile
         by clicking the user profile, in the profile pop-up, click the "More" icon(three dots), and then click "Copy member ID" button. e.g. U0600000000
       type: string
+    - default: ""
+      name: slack-group-id
+      description: |
+        The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
     - default: "v2.9.1"
       name: mce-version
       description: The version of the MCE
@@ -644,7 +648,7 @@ spec:
       params:
         - name: message
           value: |
-            :bangbang: <@$(params.slack-member-id)> PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
+            :bangbang: PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
             - git source: $(params.git-url)/commit/$(params.revision)
             - output image: $(params.output-image)
             - see details: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/$(context.pipelineRun.namespace)/applications/$(params.konflux-application-name)/pipelineruns/$(context.pipelineRun.name)
@@ -652,10 +656,16 @@ spec:
           value: $(params.slack-webhook-url-secret-name)
         - name: key-name
           value: $(params.slack-webhook-url-secret-key)
+        - name: user-ids
+          value:
+            - $(params.slack-member-id)
+        - name: group-ids
+          value:
+            - $(params.slack-group-id)
       taskRef:
         params:
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:4e68fe2225debc256d403b828ed358345bb56d03327b46d55cb6c42911375750
+            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:f81bd9de5ab2984556cbacf7ffcce91f91b03521f8644e54d47c18898c100306
           - name: name
             value: slack-webhook-notification
           - name: kind


### PR DESCRIPTION
## Summary

This PR adds support for mentioning Slack user groups in pipeline failure notifications across all pipeline files.

The upstream Konflux build-definitions now supports user and group mentions in Slack notifications via the `user-ids` and `group-ids` parameters: https://github.com/konflux-ci/build-definitions/pull/2886

## Changes Made

- **Added `slack-group-id` parameter** to all pipeline files to enable Slack user group mentions
- **Updated slack-webhook-notification task** to use `user-ids` and `group-ids` array parameters instead of hardcoded mentions
- **Removed hardcoded `<@$(params.slack-member-id)>` mention** from notification messages (now handled by the task using proper mention syntax)
- **Updated task bundle reference** to `sha256:f81bd9de5ab2984556cbacf7ffcce91f91b03521f8644e54d47c18898c100306` which supports the new parameters

## Files Updated

- `pipelines/common.yaml`
- `pipelines/common-fbc.yaml`
- `pipelines/common-oci-ta.yaml`
- `pipelines/common_mce_2.6.yaml`
- `pipelines/common_mce_2.7.yaml`
- `pipelines/common_mce_2.8.yaml`
- `pipelines/common_mce_2.9.yaml`
- `pipelines/common_mce_2.10.yaml`

## Benefits

This enhancement allows pipelines to:
- Mention individual Slack users via `slack-member-id` parameter (uses `<@USER_ID>` syntax)
- Mention entire Slack user groups via `slack-group-id` parameter (uses `<!subteam^GROUP_ID>` syntax)
- Use both parameters together for comprehensive notification coverage
- Support multiple users and groups through array parameters

## How It Works

The upstream task now:
- Accepts `user-ids` and `group-ids` as optional array parameters
- Automatically prepends proper mention syntax to messages
- Supports flexible, dynamic mentions without hardcoding in pipeline definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)