### PR TITLE
Add default MCE version build args to common pipeline

### DIFF
--- a/pipelines/common.yaml
+++ b/pipelines/common.yaml
@@ -59,7 +59,13 @@ spec:
       description: Add built image into an OCI image index
       name: build-image-index
       type: string
-    - default: []
+    - default:
+        - MCE_VERSION_2_11=v2.11.0
+        - MCE_VERSION_2_10=v2.10.0
+        - MCE_VERSION_2_9=v2.9.1
+        - MCE_VERSION_2_8=v2.8.3
+        - MCE_VERSION_2_7=v2.7.6
+        - MCE_VERSION_2_6=v2.6.8
       description: Array of --build-arg values ("arg=value" strings) for buildah
       name: build-args
       type: array


### PR DESCRIPTION
## Description

This PR adds default build-args values for MCE versions 2.6 through 2.11 to the common pipeline's `build-args` parameter. This provides default MCE version values that can be used during container builds without requiring users to specify them explicitly.

## Changes

- Add default `build-args` array with MCE version values:
  - `MCE_VERSION_2_11=2.11.0`
  - `MCE_VERSION_2_10=2.10.0`
  - `MCE_VERSION_2_9=2.9.1`
  - `MCE_VERSION_2_8=2.8.3`
  - `MCE_VERSION_2_7=2.7.6`
  - `MCE_VERSION_2_6=2.6.8`

## Testing

- YAML syntax validated with `yq`
- No linter errors detected
- Structure matches existing array parameter patterns in the pipeline

## Related

This change ensures that the common pipeline has sensible defaults for MCE version build arguments, making it easier for users to build container images with the appropriate MCE version settings.