### PR TITLE
feat: add matrix configuration to clamav-scan task

### DIFF
--- a/pipelines/common.yaml
+++ b/pipelines/common.yaml
@@ -428,6 +428,11 @@ spec:
           values:
             - "false"
     - name: clamav-scan
+      matrix:
+        params:
+        - name: image-arch
+          value:
+          - $(params.build-platforms)
       params:
         - name: image-digest
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)

--- a/pipelines/common_mce_2.10.yaml
+++ b/pipelines/common_mce_2.10.yaml
@@ -428,6 +428,11 @@ spec:
           values:
             - "false"
     - name: clamav-scan
+      matrix:
+        params:
+        - name: image-arch
+          value:
+          - $(params.build-platforms)
       params:
         - name: image-digest
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)

--- a/pipelines/common_mce_2.11.yaml
+++ b/pipelines/common_mce_2.11.yaml
@@ -428,6 +428,11 @@ spec:
           values:
             - "false"
     - name: clamav-scan
+      matrix:
+        params:
+        - name: image-arch
+          value:
+          - $(params.build-platforms)
       params:
         - name: image-digest
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)

--- a/pipelines/common_mce_2.6.yaml
+++ b/pipelines/common_mce_2.6.yaml
@@ -428,6 +428,11 @@ spec:
           values:
             - "false"
     - name: clamav-scan
+      matrix:
+        params:
+        - name: image-arch
+          value:
+          - $(params.build-platforms)
       params:
         - name: image-digest
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)

--- a/pipelines/common_mce_2.7.yaml
+++ b/pipelines/common_mce_2.7.yaml
@@ -428,6 +428,11 @@ spec:
           values:
             - "false"
     - name: clamav-scan
+      matrix:
+        params:
+        - name: image-arch
+          value:
+          - $(params.build-platforms)
       params:
         - name: image-digest
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)

--- a/pipelines/common_mce_2.8.yaml
+++ b/pipelines/common_mce_2.8.yaml
@@ -428,6 +428,11 @@ spec:
           values:
             - "false"
     - name: clamav-scan
+      matrix:
+        params:
+        - name: image-arch
+          value:
+          - $(params.build-platforms)
       params:
         - name: image-digest
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)

--- a/pipelines/common_mce_2.9.yaml
+++ b/pipelines/common_mce_2.9.yaml
@@ -427,6 +427,11 @@ spec:
           values:
             - "false"
     - name: clamav-scan
+      matrix:
+        params:
+        - name: image-arch
+          value:
+          - $(params.build-platforms)
       params:
         - name: image-digest
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)


### PR DESCRIPTION
## Summary

Add matrix configuration to clamav-scan task to align with automated Konflux bot updates. The Konflux bot automatically submits PRs (e.g., https://github.com/stolostron/ocm/pull/520/files) that include the image-arch matrix configuration for clamav-scan, but the common pipeline files in this repository do not have this configuration yet.

## Changes

This PR adds the following matrix configuration to the clamav-scan task in all multi-platform pipeline files:

```yaml
matrix:
  params:
  - name: image-arch
    value:
    - $(params.build-platforms)
```

This enables parallel scanning across multiple build platforms (linux/x86_64, linux/arm64, linux/ppc64le, linux/s390x) and ensures consistency between the common pipelines and the automated bot updates.

## Files Updated

- pipelines/common.yaml
- pipelines/common_mce_2.6.yaml
- pipelines/common_mce_2.7.yaml
- pipelines/common_mce_2.8.yaml
- pipelines/common_mce_2.9.yaml
- pipelines/common_mce_2.10.yaml
- pipelines/common_mce_2.11.yaml

**Note:** pipelines/common-oci-ta.yaml was not modified as it is a single-platform pipeline and does not have the build-platforms parameter.

## Test Plan

- [ ] Verify pipeline YAML files are valid
- [ ] Verify automated tests pass
- [ ] Verify clamav-scan task runs in parallel for each platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)