### PR TITLE
chore: migrate buildah-remote-oci-ta task bundle from 0.6 to 0.7

### DIFF
--- a/pipelines/common-fbc.yaml
+++ b/pipelines/common-fbc.yaml
@@ -323,7 +323,7 @@ spec:
       - name: name
         value: buildah-remote-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.6@sha256:b7b13a3c812daf08c7c92bbededc0c0bc1a63b64f7f6949b04c228bf383fb5da
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.7@sha256:c597a9f523b1115a88b9910267dd8f71057b0fa4f78e3dadf5a5c0affc5ea773
       - name: kind
         value: task
       resolver: bundles

--- a/pipelines/common.yaml
+++ b/pipelines/common.yaml
@@ -268,7 +268,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.6@sha256:b7b13a3c812daf08c7c92bbededc0c0bc1a63b64f7f6949b04c228bf383fb5da
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.7@sha256:c597a9f523b1115a88b9910267dd8f71057b0fa4f78e3dadf5a5c0affc5ea773
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common_mce_2.10.yaml
+++ b/pipelines/common_mce_2.10.yaml
@@ -262,7 +262,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.6@sha256:b7b13a3c812daf08c7c92bbededc0c0bc1a63b64f7f6949b04c228bf383fb5da
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.7@sha256:c597a9f523b1115a88b9910267dd8f71057b0fa4f78e3dadf5a5c0affc5ea773
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common_mce_2.11.yaml
+++ b/pipelines/common_mce_2.11.yaml
@@ -262,7 +262,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.6@sha256:b7b13a3c812daf08c7c92bbededc0c0bc1a63b64f7f6949b04c228bf383fb5da
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.7@sha256:c597a9f523b1115a88b9910267dd8f71057b0fa4f78e3dadf5a5c0affc5ea773
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common_mce_2.6.yaml
+++ b/pipelines/common_mce_2.6.yaml
@@ -262,7 +262,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.6@sha256:b7b13a3c812daf08c7c92bbededc0c0bc1a63b64f7f6949b04c228bf383fb5da
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.7@sha256:c597a9f523b1115a88b9910267dd8f71057b0fa4f78e3dadf5a5c0affc5ea773
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common_mce_2.7.yaml
+++ b/pipelines/common_mce_2.7.yaml
@@ -262,7 +262,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.6@sha256:b7b13a3c812daf08c7c92bbededc0c0bc1a63b64f7f6949b04c228bf383fb5da
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.7@sha256:c597a9f523b1115a88b9910267dd8f71057b0fa4f78e3dadf5a5c0affc5ea773
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common_mce_2.8.yaml
+++ b/pipelines/common_mce_2.8.yaml
@@ -262,7 +262,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.6@sha256:b7b13a3c812daf08c7c92bbededc0c0bc1a63b64f7f6949b04c228bf383fb5da
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.7@sha256:c597a9f523b1115a88b9910267dd8f71057b0fa4f78e3dadf5a5c0affc5ea773
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common_mce_2.9.yaml
+++ b/pipelines/common_mce_2.9.yaml
@@ -261,7 +261,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.6@sha256:b7b13a3c812daf08c7c92bbededc0c0bc1a63b64f7f6949b04c228bf383fb5da
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.7@sha256:c597a9f523b1115a88b9910267dd8f71057b0fa4f78e3dadf5a5c0affc5ea773
           - name: kind
             value: task
         resolver: bundles


### PR DESCRIPTION
## Summary

This PR migrates the buildah-remote-oci-ta Tekton task bundle from version 0.6 to 0.7 across all pipeline files in the repository.

### Migration Details

- **Task Bundle**: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta
- **Previous Version**: 0.6 (`sha256:b7b13a3c812daf08c7c92bbededc0c0bc1a63b64f7f6949b04c228bf383fb5da`)
- **New Version**: 0.7 (`sha256:c597a9f523b1115a88b9910267dd8f71057b0fa4f78e3dadf5a5c0affc5ea773`)
- **Migration Reference**: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-remote-oci-ta/0.7/MIGRATION.md

### Breaking Change

The default value of `INHERIT_BASE_IMAGE_LABELS` parameter has changed from `true` to `false`. 

**Impact**: Images will no longer automatically inherit labels from base images (e.g., ubi9). Teams should explicitly set required image labels (`name`, `cpe`, etc.) in their Dockerfiles to maintain compliance with policy checks.

### Files Updated

All common pipeline files have been updated:
- [pipelines/common.yaml](pipelines/common.yaml)
- [pipelines/common-fbc.yaml](pipelines/common-fbc.yaml)
- [pipelines/common_mce_2.6.yaml](pipelines/common_mce_2.6.yaml)
- [pipelines/common_mce_2.7.yaml](pipelines/common_mce_2.7.yaml)
- [pipelines/common_mce_2.8.yaml](pipelines/common_mce_2.8.yaml)
- [pipelines/common_mce_2.9.yaml](pipelines/common_mce_2.9.yaml)
- [pipelines/common_mce_2.10.yaml](pipelines/common_mce_2.10.yaml)
- [pipelines/common_mce_2.11.yaml](pipelines/common_mce_2.11.yaml)

## Related Issues

This PR resolves the following migration issues:
- Fixes #595
- Fixes #596
- Fixes #597
- Fixes #598
- Fixes #599
- Fixes #600
- Fixes #601
- Fixes #603

## Test Plan

- [x] All pipeline files updated with consistent bundle version and digest
- [ ] Automated Tekton pipeline tests will run via `.tekton/` configurations
- [ ] Enterprise Contract checks will validate the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)