### PR TITLE
fix: replace dots with underscores in migration issue labels

### DIFF
--- a/.github/workflows/update-tekton-task-bundles.yaml
+++ b/.github/workflows/update-tekton-task-bundles.yaml
@@ -80,7 +80,9 @@ jobs:
         run: |
           filename="${{ matrix.pipeline_file }}"
           filename_no_ext="${filename%.yaml}"
-          echo "filename_label=${filename_no_ext}" >> $GITHUB_OUTPUT
+          # Replace dots with underscores to avoid label parsing issues
+          filename_label="${filename_no_ext//./_}"
+          echo "filename_label=${filename_label}" >> $GITHUB_OUTPUT
 
       - name: Check for existing migration issue
         if: steps.check_migration.outputs.migration_required == 'true'


### PR DESCRIPTION
## Summary
- Fixed label generation for migration issues to replace dots with underscores
- Prevents label truncation issues for pipeline files with version numbers (e.g., `common_mce_2.11.yaml`)

## Problem
When migration issues are created for pipeline files like `common_mce_2.11.yaml`, the current label generation logic produces labels containing dots (e.g., `common_mce_2.11`). This can cause GitHub's label system to truncate or misparse the label, resulting in incorrect labels like `common_mce_2`.

Reference: https://github.com/stolostron/konflux-build-catalog/issues/616

## Solution
Modified the label generation logic in `.github/workflows/update-tekton-task-bundles.yaml` to replace all dots with underscores:
- `common_mce_2.11.yaml` → label: `common_mce_2_11` ✓
- `common-oci-ta.yaml` → label: `common-oci-ta` ✓
- `common-fbc.yaml` → label: `common-fbc` ✓

## Changes
- Updated the `Extract pipeline filename without extension` step to use `${filename_no_ext//./_}` for converting dots to underscores
- Added inline comment explaining the label sanitization

## Test Plan
- [ ] Verify workflow syntax is valid
- [ ] Test label generation for files with dots in names (e.g., `common_mce_2.11.yaml`)
- [ ] Ensure existing label search logic still works with new label format

🤖 Generated with [Claude Code](https://claude.com/claude-code)