### PR TITLE
fix: use comma-separated format for multiple issue labels

### DIFF
--- a/.github/workflows/update-tekton-task-bundles.yaml
+++ b/.github/workflows/update-tekton-task-bundles.yaml
@@ -115,9 +115,7 @@ jobs:
           token: ${{ github.token }}
           title: "Tekton Task Bundle Migration Required - ${{ matrix.pipeline_file }} - ${{ github.run_id }}"
           body: ${{ steps.check_migration.outputs.issue_body }}
-          labels: |
-            migration
-            ${{ steps.extract_filename.outputs.filename_label }}
+          labels: "migration, ${{ steps.extract_filename.outputs.filename_label }}"
           assignees: ${{ github.actor }}
 
       - name: Send Slack notification for migration


### PR DESCRIPTION
## Summary
- Fixed label format for migration issues to use comma-separated string instead of multi-line YAML
- Ensures two separate labels are created: migration and filename_label instead of one combined label

## Problem
When migration issues are created, the multi-line YAML format for labels is being interpreted as a **single label string** by imjohnbo/issue-bot@v3, resulting in labels like:
- migration common_mce_2_10 (one label) ❌

Instead of the intended:
- migration (label 1) ✓
- common_mce_2_10 (label 2) ✓

Reference: https://github.com/stolostron/konflux-build-catalog/issues/623

## Solution
According to the issue-bot documentation, the labels parameter requires a **comma-separated string** for multiple labels.

Changed from:
```yaml
labels: |
  migration
  filename_label
```

To:
```yaml
labels: "migration, filename_label"
```

## Result
Migration issues will now have two distinct, properly separated labels:
- migration
- common_mce_2_10 (or whichever pipeline file triggered it)

This also ensures the label search logic in the "Check for existing migration issue" step works correctly, as it searches for issues with both labels.

## Test Plan
- [ ] Verify workflow syntax is valid
- [ ] Test that migration issues are created with two separate labels
- [ ] Verify existing issue detection still works correctly with the new label format

Fixes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)