### PR TITLE
fix(common-oci-ta): migrate buildah-oci-ta task from 0.6 to 0.7

### DIFF
--- a/pipelines/common-oci-ta.yaml
+++ b/pipelines/common-oci-ta.yaml
@@ -280,7 +280,7 @@ spec:
           - name: name
             value: buildah-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.6@sha256:bb8ca56a61aa467d087b2eb5a9a9c2d1193cfba41e5b1f4de7ee9a252111f669
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.7@sha256:916781b75e5f42a2e0b578b3ab3418e8bcc305168b2cd26ff41c8057e5c9ec28
           - name: kind
             value: task
         resolver: bundles


### PR DESCRIPTION
## Summary
- Migrate `buildah-oci-ta` task bundle from version 0.6 to 0.7 in `pipelines/common-oci-ta.yaml`
- Addresses automated migration issue requiring manual intervention

## Migration Details
- **Task**: `quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta`
- **Previous version**: 0.6 (`sha256:bb8ca56a61aa467d087b2eb5a9a9c2d1193cfba41e5b1f4de7ee9a252111f669`)
- **New version**: 0.7 (`sha256:916781b75e5f42a2e0b578b3ab3418e8bcc305168b2cd26ff41c8057e5c9ec28`)

## Migration Notes
Per the [migration documentation](https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-oci-ta/0.7/MIGRATION.md):
- Version 0.7 initially changed the default value of `INHERIT_BASE_IMAGE_LABELS` from `true` to `false`
- Version 0.7.1 reverted this change, so labels are inherited by default again
- No breaking changes require pipeline parameter modifications

Fixes #647

## Test plan
- [ ] Pipeline validation passes in PR checks
- [ ] Verify the task bundle reference is correctly updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)