### PR TITLE
chore: update MCE versions to latest releases

### DIFF
--- a/pipelines/common.yaml
+++ b/pipelines/common.yaml
@@ -61,11 +61,11 @@ spec:
       type: string
     - default:
         - MCE_VERSION_2_11=v2.11.0
-        - MCE_VERSION_2_10=v2.10.0
-        - MCE_VERSION_2_9=v2.9.1
-        - MCE_VERSION_2_8=v2.8.3
-        - MCE_VERSION_2_7=v2.7.6
-        - MCE_VERSION_2_6=v2.6.8
+        - MCE_VERSION_2_10=v2.10.1
+        - MCE_VERSION_2_9=v2.9.2
+        - MCE_VERSION_2_8=v2.8.4
+        - MCE_VERSION_2_7=v2.7.8
+        - MCE_VERSION_2_6=v2.6.9
       description: Array of --build-arg values ("arg=value" strings) for buildah
       name: build-args
       type: array

--- a/pipelines/common_mce_2.10.yaml
+++ b/pipelines/common_mce_2.10.yaml
@@ -117,7 +117,7 @@ spec:
       name: slack-group-id
       description: |
         The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
-    - default: "v2.10.0"
+    - default: "v2.10.1"
       description: The version of the MCE
       name: mce-version
       type: string

--- a/pipelines/common_mce_2.6.yaml
+++ b/pipelines/common_mce_2.6.yaml
@@ -117,7 +117,7 @@ spec:
       name: slack-group-id
       description: |
         The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
-    - default: "v2.6.8"
+    - default: "v2.6.9"
       description: The version of the MCE
       name: mce-version
       type: string

--- a/pipelines/common_mce_2.7.yaml
+++ b/pipelines/common_mce_2.7.yaml
@@ -117,7 +117,7 @@ spec:
       name: slack-group-id
       description: |
         The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
-    - default: "v2.7.6"
+    - default: "v2.7.8"
       description: The version of the MCE
       name: mce-version
       type: string

--- a/pipelines/common_mce_2.8.yaml
+++ b/pipelines/common_mce_2.8.yaml
@@ -117,7 +117,7 @@ spec:
       name: slack-group-id
       description: |
         The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
-    - default: "v2.8.3"
+    - default: "v2.8.4"
       description: The version of the MCE
       name: mce-version
       type: string

--- a/pipelines/common_mce_2.9.yaml
+++ b/pipelines/common_mce_2.9.yaml
@@ -117,7 +117,7 @@ spec:
       name: slack-group-id
       description: |
         The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
-    - default: "v2.9.1"
+    - default: "v2.9.2"
       name: mce-version
       description: The version of the MCE
     - name: buildah-format


### PR DESCRIPTION
## Summary

Update MCE version defaults in pipeline files to the latest releases.

### Version Changes
| MCE Version | Previous | New |
|-------------|----------|-----|
| 2.6 | v2.6.8 | v2.6.9 |
| 2.7 | v2.7.6 | v2.7.8 |
| 2.8 | v2.8.3 | v2.8.4 |
| 2.9 | v2.9.1 | v2.9.2 |
| 2.10 | v2.10.0 | v2.10.1 |

### Version Source
Versions fetched from `Z_RELEASE_VERSION` files in the [mce-operator-bundle](https://github.com/stolostron/mce-operator-bundle) repository:
- [backplane-2.6/Z_RELEASE_VERSION](https://github.com/stolostron/mce-operator-bundle/blob/backplane-2.6/Z_RELEASE_VERSION)
- [backplane-2.7/Z_RELEASE_VERSION](https://github.com/stolostron/mce-operator-bundle/blob/backplane-2.7/Z_RELEASE_VERSION)
- [backplane-2.8/Z_RELEASE_VERSION](https://github.com/stolostron/mce-operator-bundle/blob/backplane-2.8/Z_RELEASE_VERSION)
- [backplane-2.9/Z_RELEASE_VERSION](https://github.com/stolostron/mce-operator-bundle/blob/backplane-2.9/Z_RELEASE_VERSION)
- [backplane-2.10/Z_RELEASE_VERSION](https://github.com/stolostron/mce-operator-bundle/blob/backplane-2.10/Z_RELEASE_VERSION)

### Files Updated
- `pipelines/common.yaml` - MCE_VERSION build args
- `pipelines/common_mce_2.6.yaml` - mce-version parameter
- `pipelines/common_mce_2.7.yaml` - mce-version parameter
- `pipelines/common_mce_2.8.yaml` - mce-version parameter
- `pipelines/common_mce_2.9.yaml` - mce-version parameter
- `pipelines/common_mce_2.10.yaml` - mce-version parameter

## Test plan
- [ ] Verify YAML syntax is valid
- [ ] Validate pipeline configurations work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)