### PR TITLE
chore(workflows): reduce tekton bundle update frequency to weekly

### DIFF
--- a/.github/workflows/auto-merge-automated-updates.yaml
+++ b/.github/workflows/auto-merge-automated-updates.yaml
@@ -3,7 +3,7 @@ name: Auto-merge Automated Updates
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 3 * * *" # Runs daily at 03:00 UTC (1 hour after tekton bundle update)
+    - cron: "0 3 * * 1" # Runs weekly on Monday at 03:00 UTC (1 hour after tekton bundle update)
 
 jobs:
   auto-merge:

--- a/.github/workflows/update-tekton-task-bundles.yaml
+++ b/.github/workflows/update-tekton-task-bundles.yaml
@@ -3,7 +3,7 @@ name: Update Tekton Task Bundles
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 2 * * *" # Runs daily at 02:00 UTC
+    - cron: "0 2 * * 1" # Runs weekly on Monday at 02:00 UTC
 
 jobs:
   update-tekton-task-bundles:


### PR DESCRIPTION
## Summary
- Change the schedule for `update-tekton-task-bundles` workflow from daily (02:00 UTC) to weekly (Monday 02:00 UTC)
- Change the schedule for `auto-merge-automated-updates` workflow from daily (03:00 UTC) to weekly (Monday 03:00 UTC)

This reduces the frequency of automated updates to reduce noise while still keeping the pipelines up to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)