### PR TITLE
fix(pipelines): migrate sast-unicode-check-oci-ta task from 0.3 to 0.4

### DIFF
--- a/pipelines/common.yaml
+++ b/pipelines/common.yaml
@@ -575,7 +575,7 @@ spec:
           - name: name
             value: sast-unicode-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.3@sha256:8817f5081c10d9debf25601d6d99d7eddde19435be1ff24741d9025931639959
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:0ca0203c25e22c9f12cc32436f6bf02df19fd177ba5f84926d804c711146974e
           - name: kind
             value: task
         resolver: bundles


### PR DESCRIPTION
## Summary
- Migrates the `sast-unicode-check-oci-ta` task bundle from version 0.3 to 0.4 in `pipelines/common.yaml`
- The breaking change in 0.4 is the removal of the `FIND_UNICODE_CONTROL_URL` parameter, which our pipeline does not use
- See [MIGRATION.md](https://github.com/konflux-ci/konflux-sast-tasks/blob/main/task/sast-unicode-check-oci-ta/0.4/MIGRATION.md) for details

## Test plan
- [ ] YAML validation passes (`yq eval pipelines/common.yaml`)
- [ ] CI pipeline passes with the updated task bundle

Fixes #847

🤖 Generated with [Claude Code](https://claude.com/claude-code)