### PR TITLE
chore(workflows): update workflow schedules to run on Sunday

### DIFF
--- a/.github/workflows/auto-merge-automated-updates.yaml
+++ b/.github/workflows/auto-merge-automated-updates.yaml
@@ -3,7 +3,7 @@ name: Auto-merge Automated Updates
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 4 * * 1" # Runs weekly on Monday at 04:00 UTC (1 hour after tekton bundle update)
+    - cron: "0 4 * * 0" # Runs weekly on Sunday at 04:00 UTC (4 hours after tekton bundle update)
 
 jobs:
   auto-merge:

--- a/.github/workflows/update-tekton-task-bundles.yaml
+++ b/.github/workflows/update-tekton-task-bundles.yaml
@@ -3,7 +3,7 @@ name: Update Tekton Task Bundles
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 2 * * 1" # Runs weekly on Monday at 02:00 UTC
+    - cron: "0 0 * * 0" # Runs weekly on Sunday at 00:00 UTC
 
 jobs:
   update-tekton-task-bundles:


### PR DESCRIPTION
## Summary
- Update `update-tekton-task-bundles` workflow to run on Sunday 00:00 UTC (Beijing 08:00) instead of Monday 02:00 UTC
- Update `auto-merge-automated-updates` workflow to run on Sunday 04:00 UTC (Beijing 12:00) instead of Monday 04:00 UTC

This moves the automated updates to the weekend for better timing, with auto-merge running 4 hours after the bundle update to allow CI checks to complete.

## Test plan
- [ ] Verify the cron expressions are valid
- [ ] Monitor the next scheduled run to confirm correct timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)