### PR TITLE
refactor: move KubeOpenCode task creation to independent job

### DIFF
--- a/.github/workflows/update-tekton-task-bundles.yaml
+++ b/.github/workflows/update-tekton-task-bundles.yaml
@@ -173,8 +173,65 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
+      - name: Fail if migration is required
+        run: |
+          if jq -e 'length > 0' migration_data.json; then
+            echo "Migration required for ${{ matrix.pipeline_file }}. Please review and migrate before proceeding."
+            cat migration_data.json
+            exit 1
+          fi
+
+      - name: Check if pipeline file changed
+        id: check_diff
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          if git diff --quiet pipelines/${{ matrix.pipeline_file }}; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request if needed
+        if: steps.check_diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: update Tekton Task Bundles in ${{ matrix.pipeline_file }}"
+          title: "chore: update Tekton Task Bundles in ${{ matrix.pipeline_file }}"
+          body: "Automated PR to update Tekton Task Bundles in ${{ matrix.pipeline_file }}. No migration required."
+          branch: tekton-bundle-update-${{ matrix.pipeline_file }}
+          base: main
+          add-paths: pipelines/${{ matrix.pipeline_file }}
+          signoff: true
+          labels: |
+            automated-update
+
+  create-kubeopencode-task:
+    runs-on: ubuntu-latest
+    needs: update-tekton-task-bundles
+    if: always()
+    steps:
+      - name: Check for open migration issues
+        id: check_migration_issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          migration_issues=$(gh issue list \
+            --repo ${{ github.repository }} \
+            --state open \
+            --label "migration" \
+            --json number \
+            --jq 'length')
+
+          if [ "$migration_issues" -gt 0 ]; then
+            echo "has_migration=true" >> $GITHUB_OUTPUT
+            echo "Found $migration_issues open migration issue(s)"
+          else
+            echo "has_migration=false" >> $GITHUB_OUTPUT
+            echo "No open migration issues found"
+          fi
+
       - name: Create KubeOpenCode migration task
-        if: steps.check_migration.outputs.migration_required == 'true' && steps.check_existing_issue.outputs.issue_exists == 'false'
+        if: steps.check_migration_issues.outputs.has_migration == 'true'
         env:
           KUBEOPENCODE_CLUSTER_URL: ${{ secrets.KUBEOPENCODE_CLUSTER_URL }}
           KUBEOPENCODE_TOKEN: ${{ secrets.KUBEOPENCODE_TOKEN }}
@@ -210,35 +267,3 @@ jobs:
           EOF
 
           rm -f /tmp/kubeopencode-ca.crt
-
-      - name: Fail if migration is required
-        run: |
-          if jq -e 'length > 0' migration_data.json; then
-            echo "Migration required for ${{ matrix.pipeline_file }}. Please review and migrate before proceeding."
-            cat migration_data.json
-            exit 1
-          fi
-
-      - name: Check if pipeline file changed
-        id: check_diff
-        run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          if git diff --quiet pipelines/${{ matrix.pipeline_file }}; then
-            echo "changed=false" >> $GITHUB_OUTPUT
-          else
-            echo "changed=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Create Pull Request if needed
-        if: steps.check_diff.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v6
-        with:
-          commit-message: "chore: update Tekton Task Bundles in ${{ matrix.pipeline_file }}"
-          title: "chore: update Tekton Task Bundles in ${{ matrix.pipeline_file }}"
-          body: "Automated PR to update Tekton Task Bundles in ${{ matrix.pipeline_file }}. No migration required."
-          branch: tekton-bundle-update-${{ matrix.pipeline_file }}
-          base: main
-          add-paths: pipelines/${{ matrix.pipeline_file }}
-          signoff: true
-          labels: |
-            automated-update


### PR DESCRIPTION
## Summary
- Move KubeOpenCode migration task creation from the matrix job into a separate `create-kubeopencode-task` job
- The new job runs **once** after all matrix instances complete (via `needs` + `if: always()`), avoiding duplicate Task creation when multiple pipeline files have migrations
- Checks for open migration issues via `gh issue list` to decide whether to create the KubeOpenCode Task

## Test plan
- [ ] Verify YAML syntax is valid (`yq eval`)
- [ ] Confirm the new job runs after all matrix jobs complete (even when matrix jobs fail due to migration `exit 1`)
- [ ] Confirm only one KubeOpenCode Task is created regardless of how many pipeline files have migrations
- [ ] Trigger the workflow manually (`workflow_dispatch`) to verify end-to-end behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)