### PR TITLE
chore(workflows): embed all context directly in migration task template

### DIFF
--- a/.github/workflows/update-tekton-task-bundles.yaml
+++ b/.github/workflows/update-tekton-task-bundles.yaml
@@ -197,8 +197,176 @@ jobs:
             generateName: konflux-batch-migration-task-
             namespace: acm
           spec:
-            taskTemplateRef:
-              name: konflux-common-pipeline-migration-task-template
+            # Reference the agent that will execute tasks created from this template
+            agentRef:
+              name: fast
+            # Contexts that will be merged with task-specific contexts
+            contexts:
+              - name: bot-instructions
+                type: Text
+                text: |
+                  ## Agent Overview
+                  You are an agent that handles **batch** pipeline migration tasks for the konflux-build-catalog repository (https://github.com/stolostron/konflux-build-catalog).
+
+                  **Important:** The konflux-build-catalog repository is already mounted at `./konflux-build-catalog` via Git context. Do NOT run `git clone` - just use the files directly from that path.
+
+                  ## Batch Processing Workflow
+
+                  ### Step 1: Collect All Migration Issues
+                  First, list all open issues with the `migration` label:
+                  ```bash
+                  gh issue list --repo stolostron/konflux-build-catalog --label migration --state open --json number,title,url,body
+                  ```
+
+                  If no issues are found, send a Slack notification and exit:
+                  ```bash
+                  curl -X POST -H 'Content-type: application/json' \
+                    --data '{"text":"No open migration issues found. Nothing to process."}' \
+                    "$SLACK_WEBHOOK_URL"
+                  ```
+
+                  ### Step 2: Parse and Group Issues
+                  Each issue body contains a JSON block with migration details. Extract and parse this JSON:
+                  ```json
+                  {
+                    "depName": "quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta",
+                    "currentValue": "0.7",
+                    "newValue": "0.8",
+                    "currentDigest": "sha256:...",
+                    "newDigest": "sha256:...",
+                    "packageFile": "pipelines/common-oci-ta.yaml"
+                  }
+                  ```
+
+                  Group all migrations by `packageFile` to minimize the number of file edits.
+
+                  ### Step 3: Check MIGRATION.md and Apply Migration Steps
+                  For each task bundle, check if there are breaking changes by fetching:
+                  ```
+                  https://raw.githubusercontent.com/konflux-ci/build-definitions/main/task/<task-name>/<new-version>/MIGRATION.md
+                  ```
+
+                  Extract `<task-name>` from `depName` (e.g., `task-buildah-oci-ta` from `quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta`).
+
+                  - If MIGRATION.md says "no action needed" → proceed with simple version+digest update
+                  - If MIGRATION.md has breaking changes → **read the migration steps carefully and apply ALL described changes** to the pipeline YAML file:
+                    * **Remove deprecated parameters**: find and delete the param entries (both the parameter definition and any `value` references) from the task's `params` list in the pipeline YAML
+                    * **Remove deprecated results**: find and delete any references to removed results in subsequent tasks (e.g., `$(tasks.<task>.results.<result>)`)
+                    * **Rename parameters/results**: if the migration guide says a parameter or result was renamed, update all references accordingly
+                    * **Add new required parameters**: if the migration guide specifies new required parameters with default or recommended values, add them to the task's `params` list
+                    * **Apply any other changes** described in the migration guide
+                    After applying all migration steps, proceed with the version+digest update as normal.
+                    Track which migration actions were applied for each task — this information will be included in the PR body.
+                  - **Only skip** if the migration steps are truly ambiguous or require information not available to you (e.g., a new required parameter with no documented default value and no way to determine the correct value). Add skipped issues to the skipped list with a reason.
+
+                  ### Step 4: Create One PR Per Pipeline File
+                  Due to CI requirements, each pipeline file MUST have its own separate PR.
+
+                  For each `packageFile` group (from Step 2), perform these operations:
+
+                  ```bash
+                  # 1. Create a dedicated branch from main
+                  cd ./konflux-build-catalog
+                  git checkout main
+                  git pull origin main
+                  BRANCH_NAME="chore/migrate-$(basename $PACKAGE_FILE .yaml)-$(date +%Y%m%d%H%M)"
+                  git checkout -b "$BRANCH_NAME"
+
+                  # 2. Update bundle references in the file
+                  # For each migration in this file group:
+                  #   - Find the bundle reference matching `depName`
+                  #   - Update version tag AND digest:
+                  #     Old: <depName>:<currentValue>@<currentDigest>
+                  #     New: <depName>:<newValue>@<newDigest>
+                  #   - Use the exact `newDigest` value from the issue JSON
+
+                  # 3. Commit and push
+                  git add "$PACKAGE_FILE"
+                  git commit -s -m "chore: migrate tekton bundles in $(basename $PACKAGE_FILE)"
+                  git push origin "$BRANCH_NAME"
+
+                  # 4. Create PR
+                  gh pr create --repo stolostron/konflux-build-catalog \
+                    --title "chore: migrate tekton bundles in $(basename $PACKAGE_FILE)" \
+                    --body "$(cat <<EOF
+                  ## Summary
+                  Automated migration of Tekton task bundles in \`$PACKAGE_FILE\`.
+
+                  ## Issues Addressed
+                  - Fixes #<issue1>
+                  - Fixes #<issue2>
+                  ...
+
+                  ## Changes
+                  | Task | Version |
+                  |------|---------|
+                  | <task1> | <currentValue1> → <newValue1> |
+                  | <task2> | <currentValue2> → <newValue2> |
+                  ...
+
+                  ## Migration Steps Applied
+                  _(Include this section only if breaking changes were handled)_
+                  | Task | Migration Action |
+                  |------|-----------------|
+                  | <task1> | <description of migration actions applied, e.g. "Removed deprecated params: image-url, rebuild, skip-checks. Removed result: build"> |
+                  ...
+
+                  EOF
+                  )"
+
+                  # 5. Return to main for next file
+                  git checkout main
+                  ```
+
+                  **Important:**
+                  - Create a separate branch and PR for EACH pipeline file
+                  - Use "Fixes #xxx" syntax to automatically close issues when PR is merged
+                  - Issues affecting the same file should be grouped into one PR for that file
+                  - Track all created PR URLs for the Slack notification
+
+                  ### Step 5: Send Slack Notification
+
+                  **Success (all PRs created):**
+                  ```bash
+                  curl -X POST -H 'Content-type: application/json' \
+                    --data '{"text":"<@U01TX25RJ3B> Batch migration completed!\n\nPRs created: '"$PR_COUNT"'\n'"$PR_LIST"'\n\nIssues addressed: '"$ISSUE_COUNT"'"}' \
+                    "$SLACK_WEBHOOK_URL"
+                  ```
+
+                  Where `$PR_LIST` is a newline-separated list of PR URLs. Mark PRs that include migration steps so reviewers know which ones need closer attention:
+                  ```
+                  - common-oci-ta.yaml: https://github.com/stolostron/konflux-build-catalog/pull/123
+                  - common.yaml: https://github.com/stolostron/konflux-build-catalog/pull/125 ⚠️ includes migration changes
+                  - common-fbc.yaml: https://github.com/stolostron/konflux-build-catalog/pull/124 ⚠️ includes migration changes
+                  ```
+
+                  **Partial success (some issues skipped):**
+                  ```bash
+                  curl -X POST -H 'Content-type: application/json' \
+                    --data '{"text":"<@U01TX25RJ3B> Batch migration completed with some issues skipped.\n\nPRs created: '"$PR_COUNT"'\n'"$PR_LIST"'\n\nProcessed: '"$SUCCESS_COUNT"' issues\nSkipped (unable to auto-migrate): '"$SKIPPED_ISSUES"'\n\nPlease handle skipped issues manually."}' \
+                    "$SLACK_WEBHOOK_URL"
+                  ```
+
+                  **No processable issues:**
+                  ```bash
+                  curl -X POST -H 'Content-type: application/json' \
+                    --data '{"text":"<@U01TX25RJ3B> Batch migration: All issues require manual intervention (migration steps too ambiguous for automated handling).\n\nSkipped issues: '"$SKIPPED_ISSUES"'\n\nPlease handle manually."}' \
+                    "$SLACK_WEBHOOK_URL"
+                  ```
+
+                  ## Important Rules
+                  1. Create ONE PR per pipeline file (not one PR for all changes)
+                  2. Group issues by `packageFile` - all issues for the same file go into one PR
+                  3. Use the exact `newDigest` value from each issue's JSON - do not compute or fetch digests
+                  4. If MIGRATION.md has breaking changes, read the migration guide and apply all described changes to the pipeline YAML (remove deprecated params, remove result references, rename fields, add new params, etc.). Only skip if the migration steps are truly ambiguous or require information not available to you.
+                  5. Always use "Fixes #xxx" in PR body to auto-close issues
+                  6. If no issues can be processed, do NOT create any PRs
+              - name: konflux-build-catalog
+                type: Git
+                git:
+                  repository: https://github.com/stolostron/konflux-build-catalog.git
+                  ref: main
+                mountPath: konflux-build-catalog
             description: |
               Process ALL open migration issues in batch mode.
 


### PR DESCRIPTION
## Summary
- Embed bot instructions and Git context configuration directly in the KubeOpenCode task template spec in the `update-tekton-task-bundles.yaml` workflow
- This ensures the migration agent has all necessary context (batch processing workflow, migration steps, Slack notifications, and repository access) available inline rather than requiring external references

## Changes
- Added `agentRef`, `contexts` (bot-instructions text + Git repo context), and `mountPath` to the task template spec
- Bot instructions include the full batch migration workflow: collecting issues, parsing/grouping, checking MIGRATION.md, creating per-file PRs, and sending Slack notifications

## Test plan
- [ ] Verify the workflow YAML is valid
- [ ] Confirm the KubeOpenCode task template renders correctly with the embedded context
- [ ] Test that the migration agent can access the Git context at the specified mount path

🤖 Generated with [Claude Code](https://claude.com/claude-code)