### PR TITLE
Updated common pipeline to support MCE 2.17

### DIFF
--- a/pipelines/common.yaml
+++ b/pipelines/common.yaml
@@ -60,6 +60,7 @@ spec:
       name: build-image-index
       type: string
     - default:
+        - MCE_VERSION_2_17=v2.17.0
         - MCE_VERSION_2_11=v2.11.0
         - MCE_VERSION_2_10=v2.10.1
         - MCE_VERSION_2_9=v2.9.2


### PR DESCRIPTION
### Summary
Add MCE 2.17 support to the common pipeline by including the `MCE_VERSION_2_17=v2.17.0` version reference.

This change maintains backward compatibility with existing MCE versions (2.9, 2.10, 2.11) while enabling repositories to reference MCE 2.17. The version reference is added to the pipeline's default parameters, allowing builds to use the `MCE_VERSION_2_17` variable when needed.

### Changes
- Updated `pipelines/common.yaml` to include MCE 2.17 version reference in the default parameters list