### PR TITLE
chore: update MCE versions in common.yaml

### DIFF
--- a/pipelines/common.yaml
+++ b/pipelines/common.yaml
@@ -61,11 +61,11 @@ spec:
       type: string
     - default:
         - MCE_VERSION_2_11=v2.11.0
-        - MCE_VERSION_2_10=v2.10.1
+        - MCE_VERSION_2_10=v2.10.2
         - MCE_VERSION_2_9=v2.9.2
-        - MCE_VERSION_2_8=v2.8.4
-        - MCE_VERSION_2_7=v2.7.8
-        - MCE_VERSION_2_6=v2.6.9
+        - MCE_VERSION_2_8=v2.8.5
+        - MCE_VERSION_2_7=v2.7.9
+        - MCE_VERSION_2_6=v2.6.10
       description: Array of --build-arg values ("arg=value" strings) for buildah
       name: build-args
       type: array


### PR DESCRIPTION
## Summary
- Update MCE build-arg default versions in `pipelines/common.yaml` to latest releases from [mce-operator-bundle](https://github.com/stolostron/mce-operator-bundle):
  - `MCE_VERSION_2_10`: v2.10.1 → v2.10.2
  - `MCE_VERSION_2_8`: v2.8.4 → v2.8.5
  - `MCE_VERSION_2_7`: v2.7.8 → v2.7.9
  - `MCE_VERSION_2_6`: v2.6.9 → v2.6.10
- No changes for `MCE_VERSION_2_11` (v2.11.0) and `MCE_VERSION_2_9` (v2.9.2) — already up to date

## Test plan
- [ ] Verify YAML syntax is valid (validated locally with `yq`)
- [ ] Confirm pipeline builds succeed with updated MCE versions
- [ ] Check that downstream repos referencing `pipelines/common.yaml` pick up new versions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)