### PR TITLE
feat: populate image labels from bundle metadata

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,24 @@
+name: Lint and Generate
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install ShellCheck
+        run: sudo apt-get install -y shellcheck
+
+      - name: ShellCheck scripts
+        run: shellcheck ./tasks/**/*.sh
+
+      - name: Generate tasks
+        run: |
+          ./build/generate-tasks.sh
+          git diff --exit-code

--- a/build/generate-tasks.sh
+++ b/build/generate-tasks.sh
@@ -1,0 +1,31 @@
+#! /bin/bash
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)
+task_dir=$(realpath "${script_dir}/../tasks")
+
+for task_dir in "${task_dir}"/*; do
+  if [[ ! -d ${task_dir} ]]; then
+    continue
+  fi
+
+  task_name=$(basename "${task_dir}")
+  echo "* Generating task ${task_name}"
+
+  if ! [[ -f "${task_dir}/${task_name}.yaml.template" ]]; then
+    echo "error: task template ${task_dir}/${task_name}.yaml.template not found" >&2
+    exit 1
+  fi
+
+  cp "${task_dir}/${task_name}.yaml.template" "${task_dir}/${task_name}.yaml"
+
+  for step in $(yq '.spec.steps[].name' "${task_dir}/${task_name}.yaml.template"); do
+    echo "  - Generating step ${step}"
+    step_script=$(cat "${task_dir}/${step}.sh")
+    if ! [[ -f "${task_dir}/${step}.sh" ]]; then
+      echo "error: step script ${step}.sh not found" >&2
+      exit 1
+    fi
+
+    step_script=${step_script} yq -i '.spec.steps[] |= select(.name == "'"${step}"'") |= .script = strenv(step_script)' "${task_dir}/${task_name}.yaml"
+  done
+done

--- a/pipelines/common-stage.yaml
+++ b/pipelines/common-stage.yaml
@@ -1,0 +1,708 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: stolostron-common-stage-build-pipeline
+spec:
+  description: |
+    This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
+
+    _Uses `buildah` to create a multi-platform container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. This pipeline requires that the [multi platform controller](https://github.com/konflux-ci/multi-platform-controller) is deployed and configured on your Konflux instance. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+    This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta?tab=tags)_
+  params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: []
+      description: Additional tags to add to the image
+      name: additional-tags
+      type: array
+    - default: .
+      description: Path to the source code of an application's component from where to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Force rebuild image
+      name: rebuild
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "true"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched by Cachi2
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+      type: string
+    - default: "true"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "true"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default: "false"
+      description: "Whether to enable privileged mode, should be used only with remote VMs"
+      name: privileged-nested
+      type: string
+    - default:
+        - linux/x86_64
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
+      description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
+      name: build-platforms
+      type: array
+    - default: "false"
+      description: Enable in-development package managers, such as pre-fetch rpm packages defined in RPM lockfiles.
+      name: use-dev-package-managers
+    - default: "true"
+      description: Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.
+      name: enable-symlink-check
+      type: string
+    - default: "false"
+      description: Whether to send slack notification when the pipeline run failed
+      name: send-slack-notification
+      type: string
+    - default: "" # Need to change for each release, empty for non-release
+      name: konflux-application-name
+      description: The name of the application in Konflux, this is required when send-slack-notification is true
+      type: string
+    - default: "slack-acm-notify-secret"
+      name: slack-webhook-url-secret-name
+      description: |
+        The name of the secret in the konflux tenant namespace which contains the slack webhook url, this is required when send-slack-notification is true.
+        If it does not exist, please prepare the slack webhook url for your team and contact the konflux tenant admins to create it.
+        The default secret is "slack-acm-notify-secret", which will send the slack message to the forum-acm-konflux-pipeline-status channel.
+        See details: https://konflux.pages.redhat.com/docs/users/patterns/slack-notifications.html
+      type: string
+    - default: "forum-acm-konflux-pipeline-status-webhook-url"
+      name: slack-webhook-url-secret-key
+      description: |
+        The key of the slack webhook url in the secret, this is required when send-slack-notification is true.
+        Should be changed according to how the secret slack-webhook-url-secret-name is created.
+        The default key is "forum-acm-konflux-pipeline-status-webhook-url", which will send the slack message to the forum-acm-konflux-pipeline-status channel.
+        See details: https://konflux.pages.redhat.com/docs/users/patterns/slack-notifications.html
+      type: string
+    - default: ""
+      name: slack-member-id
+      description: |
+        The member id of the slack user, if this is set will mention the user in the slack message; this id can be found in the slack user profile
+        by clicking the user profile, in the profile pop-up, click the "More" icon(three dots), and then click "Copy member ID" button. e.g. U0600000000
+      type: string
+    - default: ""
+      name: slack-group-id
+      description: |
+        The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
+    - name: buildah-format
+      default: docker
+      type: string
+      description: The format for the resulting image's mediaType. Valid values are oci or docker.
+    - name: enable-cache-proxy
+      default: "false"
+      description: Enable cache proxy configuration
+      type: string
+  results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+  workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  tasks:
+    - name: init
+      params:
+        - name: enable-cache-proxy
+          value: $(params.enable-cache-proxy)
+      taskRef:
+        params:
+          - name: name
+            value: init
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.3@sha256:aa6f8632cc23d605c5942505ff1d00280db16a6fda5c4c56c4ed9ae936b5fbc6
+          - name: kind
+            value: task
+        resolver: bundles
+
+    - name: clone-repository
+      params:
+        - name: url
+          value: $(params.git-url)
+        - name: revision
+          value: $(params.revision)
+        - name: ociStorage
+          value: $(params.output-image).git
+        - name: ociArtifactExpiresAfter
+          value: $(params.image-expires-after)
+        - name: enableSymlinkCheck
+          value: $(params.enable-symlink-check)
+      runAfter:
+        - init
+      taskRef:
+        params:
+          - name: name
+            value: git-clone-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:306b69e6db435ad4a7cf258b6219d9b998eb37da44f5e9ac882ac86a08109154
+          - name: kind
+            value: task
+        resolver: bundles
+      workspaces:
+        - name: basic-auth
+          workspace: git-auth
+
+    - name: fetch-product-metadata
+      params:
+        - name: output-image
+          value: $(params.output-image)
+      runAfter:
+        - init
+      taskRef:
+        params:
+          - name: url
+            value: https://github.com/stolostron/konflux-build-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/fetch-product-metadata/fetch-product-metadata.yaml
+        resolver: git
+
+    - name: prefetch-dependencies
+      params:
+        - name: input
+          value: $(params.prefetch-input)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+        - name: ociStorage
+          value: $(params.output-image).prefetch
+        - name: ociArtifactExpiresAfter
+          value: $(params.image-expires-after)
+        - name: dev-package-managers
+          value: $(params.use-dev-package-managers)
+      runAfter:
+        - clone-repository
+      taskRef:
+        params:
+          - name: name
+            value: prefetch-dependencies-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:c664a6df6514b59c3ce53570b0994b45af66ecc89ba2a8e41834eae0622addf6
+          - name: kind
+            value: task
+        resolver: bundles
+      workspaces:
+        - name: git-basic-auth
+          workspace: git-auth
+        - name: netrc
+          workspace: netrc
+
+    - matrix:
+        params:
+          - name: PLATFORM
+            value:
+              - $(params.build-platforms)
+      name: build-images
+      params:
+        - name: IMAGE
+          value: $(params.output-image)
+        - name: DOCKERFILE
+          value: $(params.dockerfile)
+        - name: CONTEXT
+          value: $(params.path-context)
+        - name: HERMETIC
+          value: $(params.hermetic)
+        - name: PREFETCH_INPUT
+          value: $(params.prefetch-input)
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.image-expires-after)
+        - name: COMMIT_SHA
+          value: $(tasks.clone-repository.results.commit)
+        - name: BUILD_ARGS
+          value:
+            - $(params.build-args[*])
+            - MCE_VERSION=v$(tasks.fetch-product-metadata.results.z-stream-version)
+        - name: LABELS
+          value:
+            - $(tasks.fetch-product-metadata.results.image-labels[*])
+        - name: BUILD_ARGS_FILE
+          value: $(params.build-args-file)
+        - name: PRIVILEGED_NESTED
+          value: $(params.privileged-nested)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+        - name: IMAGE_APPEND_PLATFORM
+          value: "true"
+        - name: BUILDAH_FORMAT
+          value: $(params.buildah-format)
+      runAfter:
+        - prefetch-dependencies
+        - fetch-product-metadata
+      taskRef:
+        params:
+          - name: name
+            value: buildah-remote-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.8@sha256:da99fce12bf72da86f6a86a5370d826c16ea8db001d27181dcaf087af9ab60cb
+          - name: kind
+            value: task
+        resolver: bundles
+
+    - name: build-image-index
+      params:
+        - name: IMAGE
+          value: $(params.output-image)
+        - name: COMMIT_SHA
+          value: $(tasks.clone-repository.results.commit)
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.image-expires-after)
+        - name: ALWAYS_BUILD_INDEX
+          value: $(params.build-image-index)
+        - name: IMAGES
+          value:
+            - $(tasks.build-images.results.IMAGE_REF[*])
+        - name: BUILDAH_FORMAT
+          value: $(params.buildah-format)
+      runAfter:
+        - build-images
+      taskRef:
+        params:
+          - name: name
+            value: build-image-index
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:05d3d8a5ded44c51b074a56a408ddf5d65c56b4c15e110abb1a99e3aff269d49
+          - name: kind
+            value: task
+        resolver: bundles
+
+    - name: build-source-image
+      params:
+        - name: BINARY_IMAGE
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: BINARY_IMAGE_DIGEST
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: source-build-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:c35ba219390d77a48ee19347e5ee8d13e5c23e3984299e02291d6da1ed8a986c
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.build-source-image)
+          operator: in
+          values:
+            - "true"
+
+    - name: deprecated-base-image-check
+      params:
+        - name: IMAGE_URL
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: deprecated-image-check
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:e3a55ccdf1091b4a35507f9ee2d1918d8e89a5f96babcb5486b491226da03d6f
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+
+    - matrix:
+        params:
+          - name: image-platform
+            value:
+              - $(params.build-platforms)
+      name: clair-scan
+      params:
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: clair-scan
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:dadfea7633d82e4303ba73d5e9c7e2bc16834bde0fd7688880453b26452067eb
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+
+    - name: ecosystem-cert-preflight-checks
+      params:
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: ecosystem-cert-preflight-checks
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:204fd3914d83c7b60e8eee72b5a944337720c79a3e660e7c994435456dcf7175
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+
+    - name: sast-snyk-check
+      params:
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: sast-snyk-check-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:0fc62e57ab2c75adf5eaa5c3e5aaeb4845dbf029ddd159b688bc5804579b639f
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+
+    - name: clamav-scan
+      matrix:
+        params:
+          - name: image-arch
+            value:
+              - $(params.build-platforms)
+      params:
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: clamav-scan
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:76efc0119a10bc8a420dbbb0cdab9ef8eafd263f6827498d2b644e450e93f446
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+
+    - name: sast-coverity-check
+      params:
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: IMAGE
+          value: $(params.output-image)
+        - name: DOCKERFILE
+          value: $(params.dockerfile)
+        - name: CONTEXT
+          value: $(params.path-context)
+        - name: HERMETIC
+          value: $(params.hermetic)
+        - name: PREFETCH_INPUT
+          value: $(params.prefetch-input)
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.image-expires-after)
+        - name: COMMIT_SHA
+          value: $(tasks.clone-repository.results.commit)
+        - name: BUILD_ARGS
+          value:
+            - $(params.build-args[*])
+        - name: BUILD_ARGS_FILE
+          value: $(params.build-args-file)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+        - coverity-availability-check
+      taskRef:
+        params:
+          - name: name
+            value: sast-coverity-check-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:6beddd6cb6da32860dd96b319e556b2335787970495b5b35537289e78eeb2aa9
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+        - input: $(tasks.coverity-availability-check.results.STATUS)
+          operator: in
+          values:
+            - success
+
+    - name: coverity-availability-check
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: coverity-availability-check
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:dc61651cb22ddca5215fc5e537066c5220668c3f06641d9c3558dd15ff089cd7
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+
+    - name: sast-shell-check
+      params:
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: sast-shell-check-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:1f67b661458c549ab299bcdddb5e2b799af8c89d3c594567eb654d870000b5ec
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+
+    - name: sast-unicode-check
+      params:
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: sast-unicode-check-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:9d2ab1bcd65f56ce32fe366a955abc8ac76228734a3f3642ac9af8af86fbb4d1
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+
+    - name: apply-tags
+      params:
+        - name: IMAGE_URL
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: ADDITIONAL_TAGS
+          value: $(params.additional-tags[*])
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: apply-tags
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:510b6d2a3b188adeb716e49566b57d611ab36bd69a2794b5ddfc11dbf014c2ca
+          - name: kind
+            value: task
+        resolver: bundles
+
+    - name: push-dockerfile
+      params:
+        - name: IMAGE
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: DOCKERFILE
+          value: $(params.dockerfile)
+        - name: CONTEXT
+          value: $(params.path-context)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: push-dockerfile-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:08bba4a659ecd48f871bef00b80af58954e5a09fcbb28a1783ddd640c4f6535e
+          - name: kind
+            value: task
+        resolver: bundles
+
+    - name: rpms-signature-scan
+      params:
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: rpms-signature-scan
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:fb6c97a57e221fa106a8b45be3e12c49e7124a3a8e2a0f0d5fbaeb17b5bf68a5
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+
+  finally:
+    - name: show-sbom
+      params:
+        - name: IMAGE_URL
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+      taskRef:
+        params:
+          - name: name
+            value: show-sbom
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:e2c1b4eac642f32e91f3bc5d3cb48c5c70888aaf45c3650d9ea34573de7a7fd5
+          - name: kind
+            value: task
+        resolver: bundles
+    - name: slack-webhook-notification
+      params:
+        - name: message
+          value: |
+            :bangbang: PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
+            - git source: $(params.git-url)/commit/$(params.revision)
+            - output image: $(params.output-image)
+            - see details: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/$(context.pipelineRun.namespace)/applications/$(params.konflux-application-name)/pipelineruns/$(context.pipelineRun.name)
+        - name: secret-name
+          value: $(params.slack-webhook-url-secret-name)
+        - name: key-name
+          value: $(params.slack-webhook-url-secret-key)
+        - name: user-ids
+          value:
+            - $(params.slack-member-id)
+        - name: group-ids
+          value:
+            - $(params.slack-group-id)
+      taskRef:
+        params:
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:69945a30c11387a766e3d0ae33991b68e865a290c09da1fea44f193d358926ba
+          - name: name
+            value: slack-webhook-notification
+          - name: kind
+            value: Task
+        resolver: bundles
+      when:
+        - input: $(tasks.status)
+          operator: in
+          values:
+            - "Failed"
+        - input: $(params.send-slack-notification)
+          operator: in
+          values:
+            - "true"

--- a/tasks/fetch-product-metadata/fetch-product-metadata.yaml
+++ b/tasks/fetch-product-metadata/fetch-product-metadata.yaml
@@ -1,0 +1,168 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: fetch-product-metadata
+spec:
+  description: >-
+    Fetch ACM/MCE metadata from the bundle repository.
+  params:
+    - name: output-image
+      type: string
+      description: >-
+        The output image or image repository from which to parse the component, product, and version. The image repository is expected to be in the form [<registry>/<org>/<namespace>/]<component>-{acm|mce}-<XY>[:<tag>].
+  results:
+    - name: z-stream-version
+      description: Semantic z-stream version (i.e. without the 'v' prefix)
+    - name: image-labels
+      description: Image labels to apply to the container image
+      type: array
+  stepTemplate:
+    image: quay.io/konflux-ci/task-runner:1.3.0@sha256:3f007bf58821885f8aa30d72c84fcbfcb14babc6521eaf6ac1bc4f8c078d9e58
+  steps:
+    - name: parse-output-image
+      displayName: Parse data from output image
+      env:
+        - name: OUTPUT_IMAGE
+          value: $(params.output-image)
+      results:
+        - name: component
+          description: Name of the Konflux component
+        - name: product
+          description: Name of the product (ACM or MCE)
+        - name: branch
+          description: Branch associated with the product version
+      script: |-
+        # shellcheck shell=bash
+
+        # Expected format: [<registry>/<repo>/<build-namespace>/]<component>-{acm|mce}-<XY>[:<tag>]
+        echo "* Parsing output image"
+        echo "  Output image: '${OUTPUT_IMAGE}'"
+        if [[ -z ${OUTPUT_IMAGE} ]]; then
+          echo "error: output-image parameter is empty" >&2
+          exit 1
+        fi
+
+        echo "* Extracting image repository"
+        output_image_repo=$(echo "${OUTPUT_IMAGE}" | grep -oE '[a-z0-9-]+-(acm|mce)-[0-9]+')
+        echo "  Image repository: '${output_image_repo}'"
+        if [[ -z ${output_image_repo} ]]; then
+          echo "error: failed to parse image repository from image '${OUTPUT_IMAGE}'" >&2
+          exit 1
+        fi
+        echo "* Extracting component"
+        component=$(echo "${output_image_repo}" | sed -E 's/-(acm|mce)-[0-9]+//')
+        echo "  Component: '${component}'"
+        if [[ -z ${component} ]] || [[ ${component} == "${output_image_repo}" ]]; then
+          echo "error: failed to parse component from image repository '${output_image_repo}'" >&2
+          exit 1
+        fi
+
+        echo "* Extracting product"
+        product=$(echo "${output_image_repo#"${component}-"}" | cut -d '-' -f 1)
+        echo "  Product: '${product}'"
+        if [[ -z ${product} ]] || [[ ${product} == "${output_image_repo}" ]]; then
+          echo "error: failed to parse product from image repository '${output_image_repo}'" >&2
+          exit 1
+        fi
+
+        case ${product} in
+        "acm")
+          branch="release"
+          ;;
+        "mce")
+          branch="backplane"
+          ;;
+        *)
+          echo "error: unexpected product '${product}' from image repository '${output_image_repo}': product must be 'acm' or 'mce'" >&2
+          exit 1
+          ;;
+        esac
+
+        echo "* Extracting version"
+        parsed_version=${output_image_repo#"${component}-${product}-"}
+        version_y=${parsed_version#[0-9]}
+        version_x=${parsed_version%"${version_y}"}
+        version="${version_x}.${version_y}"
+
+        echo "  Version: '${parsed_version}' -> '${version}'"
+        if [[ -z ${parsed_version} ]] || [[ -z ${version_x} ]] || [[ -z ${version_y} ]] ||
+          [[ ${version_x} == "${parsed_version}" ]] || [[ ${version_y} == "${parsed_version}" ]] ||
+          [[ ${version_x} == "${product}" ]] || [[ ${version_y} == "${product}" ]]; then
+          echo "error: failed to parse version from image repository '${output_image_repo}'" >&2
+          exit 1
+        fi
+
+        # Write results for next steps to pipeline results files
+        echo -n "${component}" >"$(step.results.component.path)"
+        echo -n "${product}" >"$(step.results.product.path)"
+        echo -n "${branch}-${version}" >"$(step.results.branch.path)"
+    - name: parse-product-metadata
+      displayName: Clone bundle repository and parse product metadata
+      env:
+        - name: COMPONENT
+          value: $(steps.parse-output-image.results.component)
+        - name: PRODUCT
+          value: $(steps.parse-output-image.results.product)
+        - name: BRANCH
+          value: $(steps.parse-output-image.results.branch)
+      script: |-
+        # shellcheck shell=bash
+
+        repo="${PRODUCT}-operator-bundle"
+
+        echo "* Cloning '${repo}' repository at branch '${BRANCH}'"
+        git clone \
+          --depth 1 \
+          --branch "${BRANCH}" \
+          "https://github.com/stolostron/${repo}"
+
+        cd "${repo}" || {
+          echo "error: failed to change directory to '${repo}'" >&2
+          exit 1
+        }
+
+        echo "* Extracting Z-stream version"
+        if ! [[ -f Z_RELEASE_VERSION ]]; then
+          echo "error: Z_RELEASE_VERSION file not found" >&2
+          exit 1
+        fi
+
+        z_stream_version=$(cat Z_RELEASE_VERSION)
+        echo "  Z-stream version: '${z_stream_version}'"
+
+        echo "* Extracting GA image repository"
+        config_path="config/${PRODUCT}-manifest-gen-config.json"
+        if ! [[ -f ${config_path} ]]; then
+          echo "error: ${config_path} file not found" >&2
+          exit 1
+        fi
+
+        ga_image_namespace=$(jq -r '.["product-images"].["image-namespace"] // ""' "${config_path}")
+        ga_image_name=$(
+          jq -er '.["product-images"].["image-list"][]
+            | select(.["konflux-component-name"] == "'"${COMPONENT}"'")
+            | .["publish-name"] // ""' "${config_path}"
+        )
+        echo "  GA image namespace: '${ga_image_namespace}'"
+        echo "  GA image name: '${ga_image_name}'"
+        if [[ -z ${ga_image_namespace} ]] || [[ -z ${ga_image_name} ]]; then
+          echo "error: failed to parse GA image namespace or name from ${config_path}" >&2
+          exit 1
+        fi
+
+        if [[ ${PRODUCT} == "mce" ]]; then
+          PRODUCT="multicluster_engine"
+        fi
+
+        # Write results for task result files
+        cpe="cpe:/a:redhat:${PRODUCT}:${BRANCH#*-}::${ga_image_name##*-rh}"
+        name="${ga_image_namespace}/${ga_image_name}"
+        version="v${z_stream_version}"
+
+        echo "* Writing results to task result files"
+        echo -n "  z-stream-version: "
+        echo -n "${z_stream_version}" | tee "$(results.z-stream-version.path)"
+        echo
+        echo -n "  image-labels: "
+        printf '["cpe=%s","name=%s","version=%s"]' "${cpe}" "${name}" "${version}" | tee "$(results.image-labels.path)"
+        echo

--- a/tasks/fetch-product-metadata/fetch-product-metadata.yaml.template
+++ b/tasks/fetch-product-metadata/fetch-product-metadata.yaml.template
@@ -1,0 +1,49 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: fetch-product-metadata
+spec:
+  description: >-
+    Fetch ACM/MCE metadata from the bundle repository.
+  params:
+    - name: output-image
+      type: string
+      description: >-
+        The output image or image repository from which to parse the component,
+        product, and version. The image repository is expected to be in the
+        form [<registry>/<org>/<namespace>/]<component>-{acm|mce}-<XY>[:<tag>].
+  results:
+    - name: z-stream-version
+      description: Semantic z-stream version (i.e. without the 'v' prefix)
+    - name: image-labels
+      description: Image labels to apply to the container image
+      type: array
+
+  stepTemplate:
+    image: quay.io/konflux-ci/task-runner:1.3.0@sha256:3f007bf58821885f8aa30d72c84fcbfcb14babc6521eaf6ac1bc4f8c078d9e58
+
+  steps:
+    - name: parse-output-image
+      displayName: Parse data from output image
+      env:
+        - name: OUTPUT_IMAGE
+          value: $(params.output-image)
+      results:
+        - name: component
+          description: Name of the Konflux component
+        - name: product
+          description: Name of the product (ACM or MCE)
+        - name: branch
+          description: Branch associated with the product version
+      script: echo "unimplemented"; exit 1
+
+    - name: parse-product-metadata
+      displayName: Clone bundle repository and parse product metadata
+      env:
+        - name: COMPONENT
+          value: $(steps.parse-output-image.results.component)
+        - name: PRODUCT
+          value: $(steps.parse-output-image.results.product)
+        - name: BRANCH
+          value: $(steps.parse-output-image.results.branch)
+      script: echo "unimplemented"; exit 1

--- a/tasks/fetch-product-metadata/parse-output-image.sh
+++ b/tasks/fetch-product-metadata/parse-output-image.sh
@@ -1,0 +1,64 @@
+# shellcheck shell=bash
+
+# Expected format: [<registry>/<repo>/<build-namespace>/]<component>-{acm|mce}-<XY>[:<tag>]
+echo "* Parsing output image"
+echo "  Output image: '${OUTPUT_IMAGE}'"
+if [[ -z ${OUTPUT_IMAGE} ]]; then
+  echo "error: output-image parameter is empty" >&2
+  exit 1
+fi
+
+echo "* Extracting image repository"
+output_image_repo=$(echo "${OUTPUT_IMAGE}" | grep -oE '[a-z0-9-]+-(acm|mce)-[0-9]+')
+echo "  Image repository: '${output_image_repo}'"
+if [[ -z ${output_image_repo} ]]; then
+  echo "error: failed to parse image repository from image '${OUTPUT_IMAGE}'" >&2
+  exit 1
+fi
+echo "* Extracting component"
+component=$(echo "${output_image_repo}" | sed -E 's/-(acm|mce)-[0-9]+//')
+echo "  Component: '${component}'"
+if [[ -z ${component} ]] || [[ ${component} == "${output_image_repo}" ]]; then
+  echo "error: failed to parse component from image repository '${output_image_repo}'" >&2
+  exit 1
+fi
+
+echo "* Extracting product"
+product=$(echo "${output_image_repo#"${component}-"}" | cut -d '-' -f 1)
+echo "  Product: '${product}'"
+if [[ -z ${product} ]] || [[ ${product} == "${output_image_repo}" ]]; then
+  echo "error: failed to parse product from image repository '${output_image_repo}'" >&2
+  exit 1
+fi
+
+case ${product} in
+"acm")
+  branch="release"
+  ;;
+"mce")
+  branch="backplane"
+  ;;
+*)
+  echo "error: unexpected product '${product}' from image repository '${output_image_repo}': product must be 'acm' or 'mce'" >&2
+  exit 1
+  ;;
+esac
+
+echo "* Extracting version"
+parsed_version=${output_image_repo#"${component}-${product}-"}
+version_y=${parsed_version#[0-9]}
+version_x=${parsed_version%"${version_y}"}
+version="${version_x}.${version_y}"
+
+echo "  Version: '${parsed_version}' -> '${version}'"
+if [[ -z ${parsed_version} ]] || [[ -z ${version_x} ]] || [[ -z ${version_y} ]] ||
+  [[ ${version_x} == "${parsed_version}" ]] || [[ ${version_y} == "${parsed_version}" ]] ||
+  [[ ${version_x} == "${product}" ]] || [[ ${version_y} == "${product}" ]]; then
+  echo "error: failed to parse version from image repository '${output_image_repo}'" >&2
+  exit 1
+fi
+
+# Write results for next steps to pipeline results files
+echo -n "${component}" >"$(step.results.component.path)"
+echo -n "${product}" >"$(step.results.product.path)"
+echo -n "${branch}-${version}" >"$(step.results.branch.path)"

--- a/tasks/fetch-product-metadata/parse-product-metadata.sh
+++ b/tasks/fetch-product-metadata/parse-product-metadata.sh
@@ -1,0 +1,60 @@
+# shellcheck shell=bash
+
+repo="${PRODUCT}-operator-bundle"
+
+echo "* Cloning '${repo}' repository at branch '${BRANCH}'"
+git clone \
+  --depth 1 \
+  --branch "${BRANCH}" \
+  "https://github.com/stolostron/${repo}"
+
+cd "${repo}" || {
+  echo "error: failed to change directory to '${repo}'" >&2
+  exit 1
+}
+
+echo "* Extracting Z-stream version"
+if ! [[ -f Z_RELEASE_VERSION ]]; then
+  echo "error: Z_RELEASE_VERSION file not found" >&2
+  exit 1
+fi
+
+z_stream_version=$(cat Z_RELEASE_VERSION)
+echo "  Z-stream version: '${z_stream_version}'"
+
+echo "* Extracting GA image repository"
+config_path="config/${PRODUCT}-manifest-gen-config.json"
+if ! [[ -f ${config_path} ]]; then
+  echo "error: ${config_path} file not found" >&2
+  exit 1
+fi
+
+ga_image_namespace=$(jq -r '.["product-images"].["image-namespace"] // ""' "${config_path}")
+ga_image_name=$(
+  jq -er '.["product-images"].["image-list"][]
+    | select(.["konflux-component-name"] == "'"${COMPONENT}"'")
+    | .["publish-name"] // ""' "${config_path}"
+)
+echo "  GA image namespace: '${ga_image_namespace}'"
+echo "  GA image name: '${ga_image_name}'"
+if [[ -z ${ga_image_namespace} ]] || [[ -z ${ga_image_name} ]]; then
+  echo "error: failed to parse GA image namespace or name from ${config_path}" >&2
+  exit 1
+fi
+
+if [[ ${PRODUCT} == "mce" ]]; then
+  PRODUCT="multicluster_engine"
+fi
+
+# Write results for task result files
+cpe="cpe:/a:redhat:${PRODUCT}:${BRANCH#*-}::${ga_image_name##*-rh}"
+name="${ga_image_namespace}/${ga_image_name}"
+version="v${z_stream_version}"
+
+echo "* Writing results to task result files"
+echo -n "  z-stream-version: "
+echo -n "${z_stream_version}" | tee "$(results.z-stream-version.path)"
+echo
+echo -n "  image-labels: "
+printf '["cpe=%s","name=%s","version=%s"]' "${cpe}" "${name}" "${version}" | tee "$(results.image-labels.path)"
+echo


### PR DESCRIPTION
There are a couple things here:
- A stage pipeline (that we could delete or continue to use as a sandbox)
- A new tasks directory with a generation script so that the scripts can live outside the YAML to enable syntax highlighting in IDEs and Shellcheck to monitor them
- A new task, `fetch-product-metadata`, that pulls the respective bundle repo to fetch the CPE, GA image repo, and z-stream version to populate image labels `cpe`, `version`, and `name`.
- The stage pipeline is populated with the new task via a git resolver.

Sample PR: https://github.com/stolostron/cert-policy-controller/pull/801
Sample run: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/crt-redhat-acm-tenant/applications/release-acm-216/pipelineruns/cert-policy-controller-acm-216-on-pull-request-zmq75