### PR TITLE
fix: return last match from image

### DIFF
--- a/tasks/fetch-product-metadata/fetch-product-metadata.yaml
+++ b/tasks/fetch-product-metadata/fetch-product-metadata.yaml
@@ -43,7 +43,7 @@ spec:
         fi
 
         echo "* Extracting image repository"
-        output_image_repo=$(echo "${OUTPUT_IMAGE}" | grep -oE '[a-z0-9-]+-(acm|mce)-[0-9]+' || true)
+        output_image_repo=$(echo "${OUTPUT_IMAGE}" | grep -oE '[a-z0-9-]+-(acm|mce)-[0-9]+' | tail -n 1 )
         echo "  Image repository: '${output_image_repo}'"
         if [[ -z ${output_image_repo} ]]; then
           echo "error: failed to parse ACM or MCE image repository from image '${OUTPUT_IMAGE}'" >&2

--- a/tasks/fetch-product-metadata/parse-output-image.sh
+++ b/tasks/fetch-product-metadata/parse-output-image.sh
@@ -9,7 +9,7 @@ if [[ -z ${OUTPUT_IMAGE} ]]; then
 fi
 
 echo "* Extracting image repository"
-output_image_repo=$(echo "${OUTPUT_IMAGE}" | grep -oE '[a-z0-9-]+-(acm|mce)-[0-9]+' || true)
+output_image_repo=$(echo "${OUTPUT_IMAGE}" | grep -oE '[a-z0-9-]+-(acm|mce)-[0-9]+' | tail -n 1 )
 echo "  Image repository: '${output_image_repo}'"
 if [[ -z ${output_image_repo} ]]; then
   echo "error: failed to parse ACM or MCE image repository from image '${OUTPUT_IMAGE}'" >&2


### PR DESCRIPTION
Sometimes the Konflux application is also part of the image path, but the application also matches the pattern of the repository, so we need to omit it.

For example, `quay.io/redhat-user-workloads/crt-redhat-acm-tenant/release-acm-212/cert-policy-controller-acm-212:on-pr-4ed40d77de4` has `release-acm-212`, which was errantly causing a second match and throwing off the parsing.

Followup to:
- #885