### PR TITLE
apply the workaround for the fips issue in konflux

### DIFF
--- a/pipelines/common-base.yaml
+++ b/pipelines/common-base.yaml
@@ -420,9 +420,9 @@ spec:
     - name: clamav-scan
       matrix:
         params:
-        - name: image-arch
-          value:
-          - $(params.build-platforms)
+          - name: image-arch
+            value:
+              - $(params.build-platforms)
       params:
         - name: image-digest
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)

--- a/pipelines/common-fbc-nofips.yaml
+++ b/pipelines/common-fbc-nofips.yaml
@@ -1,0 +1,500 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: stolostron-common-fbc-nofips-builder-pipeline
+spec:
+  description: |
+    This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/end-to-end/building-olm/#building-the-file-based-catalog).
+    Do not use this pipeline unless you intend to run without the FIPS validation check.
+
+    _Uses `buildah` to create a container image. Its build-time tests are limited to verifying the included catalog and do not scan the image.
+    This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-fbc-builder?tab=tags)_
+  finally:
+    - name: show-sbom
+      params:
+        - name: IMAGE_URL
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+      taskRef:
+        params:
+          - name: name
+            value: show-sbom
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:e2c1b4eac642f32e91f3bc5d3cb48c5c70888aaf45c3650d9ea34573de7a7fd5
+          - name: kind
+            value: task
+        resolver: bundles
+    - name: slack-webhook-notification
+      params:
+        - name: message
+          value: |
+            :bangbang: PipelineRun name: $(context.pipelineRun.name) id: $(context.pipelineRun.uid) failed:
+            - git source: $(params.git-url)/commit/$(params.revision)
+            - output image: $(params.output-image)
+            - see details: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/$(context.pipelineRun.namespace)/applications/$(params.konflux-application-name)/pipelineruns/$(context.pipelineRun.name)
+        - name: secret-name
+          value: $(params.slack-webhook-url-secret-name)
+        - name: key-name
+          value: $(params.slack-webhook-url-secret-key)
+        - name: user-ids
+          value:
+            - $(params.slack-member-id)
+        - name: group-ids
+          value:
+            - $(params.slack-group-id)
+      taskRef:
+        params:
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:69945a30c11387a766e3d0ae33991b68e865a290c09da1fea44f193d358926ba
+          - name: name
+            value: slack-webhook-notification
+          - name: kind
+            value: Task
+        resolver: bundles
+      when:
+        - input: $(tasks.status)
+          operator: in
+          values:
+            - "Failed"
+        - input: $(params.send-slack-notification)
+          operator: in
+          values:
+            - "true"
+  params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: []
+      description: Additional tags to add to the image
+      name: additional-tags
+      type: array
+    - default: .
+      description:
+        Path to the source code of an application's component from where
+        to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description:
+        Path to the Dockerfile inside the context specified by parameter
+        path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Force rebuild image
+      name: rebuild
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "true"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched by Cachi2
+      name: prefetch-input
+      type: string
+    - default: ""
+      description:
+        Image tag expiration time, time values could be something like
+        1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+      type: string
+    - default: "true"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "true"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default:
+        - linux/x86_64
+      description:
+        List of platforms to build the container images on. The available
+        set of values is determined by the configuration of the multi-platform-controller.
+      name: build-platforms
+      type: array
+    - default: []
+      description: An array of arguments passed to opm when executed.
+      name: opm-args
+      type: array
+    - default: ""
+      description: The path where the output from opm will be stored (i.e., where catalog.json will be saved).
+      name: opm-output-path
+      type: string
+    - default: ""
+      description: The path to the ImageDigestMirrorSet file in YAML format.
+      name: idms-path
+      type: string
+    - default: "false"
+      description: Whether to send slack notification when the pipeline run failed
+      name: send-slack-notification
+      type: string
+    - default: "" # Need to change for each release, empty for non-release
+      name: konflux-application-name
+      description: The name of the application in Konflux, this is required when send-slack-notification is true
+      type: string
+    - default: "slack-acm-notify-secret"
+      name: slack-webhook-url-secret-name
+      description: |
+        The name of the secret in the konflux tenant namespace which contains the slack webhook url, this is required when send-slack-notification is true.
+        If it does not exist, please prepare the slack webhook url for your team and contact the konflux tenant admins to create it.
+        The default secret is "slack-acm-notify-secret", which will send the slack message to the forum-acm-konflux-pipeline-status channel.
+        See details: https://konflux.pages.redhat.com/docs/users/patterns/slack-notifications.html
+      type: string
+    - default: "forum-acm-konflux-pipeline-status-webhook-url"
+      name: slack-webhook-url-secret-key
+      description: |
+        The key of the slack webhook url in the secret, this is required when send-slack-notification is true.
+        Should be changed according to how the secret slack-webhook-url-secret-name is created.
+        The default key is "forum-acm-konflux-pipeline-status-webhook-url", which will send the slack message to the forum-acm-konflux-pipeline-status channel.
+        See details: https://konflux.pages.redhat.com/docs/users/patterns/slack-notifications.html
+      type: string
+    - default: ""
+      name: slack-member-id
+      description: |
+        The member id of the slack user, if this is set will mention the user in the slack message; this id can be found in the slack user profile
+        by clicking the user profile, in the profile pop-up, click the "More" icon(three dots), and then click "Copy member ID" button. e.g. U0600000000
+      type: string
+    - default: ""
+      name: slack-group-id
+      description: |
+        The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
+    - name: enable-cache-proxy
+      default: "false"
+      description: Enable cache proxy configuration
+      type: string
+  results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+  tasks:
+    - name: init
+      params:
+        - name: enable-cache-proxy
+          value: $(params.enable-cache-proxy)
+      taskRef:
+        params:
+          - name: name
+            value: init
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.3@sha256:aa6f8632cc23d605c5942505ff1d00280db16a6fda5c4c56c4ed9ae936b5fbc6
+          - name: kind
+            value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+        - name: url
+          value: $(params.git-url)
+        - name: revision
+          value: $(params.revision)
+        - name: ociStorage
+          value: $(params.output-image).git
+        - name: ociArtifactExpiresAfter
+          value: $(params.image-expires-after)
+      runAfter:
+        - init
+      taskRef:
+        params:
+          - name: name
+            value: git-clone-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:306b69e6db435ad4a7cf258b6219d9b998eb37da44f5e9ac882ac86a08109154
+          - name: kind
+            value: task
+        resolver: bundles
+      workspaces:
+        - name: basic-auth
+          workspace: git-auth
+    - name: run-opm-command
+      params:
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+        - name: ociStorage
+          value: $(params.output-image).opm
+        - name: ociArtifactExpiresAfter
+          value: $(params.image-expires-after)
+        - name: OPM_ARGS
+          value:
+            - $(params.opm-args[*])
+        - name: OPM_OUTPUT_PATH
+          value: $(params.opm-output-path)
+        - name: IDMS_PATH
+          value: $(params.idms-path)
+      runAfter:
+        - clone-repository
+      taskRef:
+        params:
+          - name: name
+            value: run-opm-command-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-run-opm-command-oci-ta:0.1@sha256:671866aa9acb0ec82ef6112411e494eceb2e71786b0519bcd0e60e61e207034e
+          - name: kind
+            value: task
+        resolver: bundles
+    - name: prefetch-dependencies
+      params:
+        - name: input
+          value: $(params.prefetch-input)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.run-opm-command.results.SOURCE_ARTIFACT)
+        - name: ociStorage
+          value: $(params.output-image).prefetch
+        - name: ociArtifactExpiresAfter
+          value: $(params.image-expires-after)
+      runAfter:
+        - run-opm-command
+      taskRef:
+        params:
+          - name: name
+            value: prefetch-dependencies-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:c664a6df6514b59c3ce53570b0994b45af66ecc89ba2a8e41834eae0622addf6
+          - name: kind
+            value: task
+        resolver: bundles
+      workspaces:
+        - name: git-basic-auth
+          workspace: git-auth
+        - name: netrc
+          workspace: netrc
+    - matrix:
+        params:
+          - name: PLATFORM
+            value:
+              - $(params.build-platforms)
+      name: build-images
+      params:
+        - name: IMAGE
+          value: $(params.output-image)
+        - name: DOCKERFILE
+          value: $(params.dockerfile)
+        - name: CONTEXT
+          value: $(params.path-context)
+        - name: HERMETIC
+          value: $(params.hermetic)
+        - name: PREFETCH_INPUT
+          value: $(params.prefetch-input)
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.image-expires-after)
+        - name: COMMIT_SHA
+          value: $(tasks.clone-repository.results.commit)
+        - name: BUILD_ARGS
+          value:
+            - $(params.build-args[*])
+        - name: BUILD_ARGS_FILE
+          value: $(params.build-args-file)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+        - name: IMAGE_APPEND_PLATFORM
+          value: "true"
+      runAfter:
+        - clone-repository
+      taskRef:
+        params:
+          - name: name
+            value: buildah-remote-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.8@sha256:417f776b6be35d6e51d9133ef8f0540f20ff80d761c76de37fb0e51786918950
+          - name: kind
+            value: task
+        resolver: bundles
+    - name: build-image-index
+      params:
+        - name: IMAGE
+          value: $(params.output-image)
+        - name: COMMIT_SHA
+          value: $(tasks.clone-repository.results.commit)
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.image-expires-after)
+        - name: ALWAYS_BUILD_INDEX
+          value: $(params.build-image-index)
+        - name: IMAGES
+          value:
+            - $(tasks.build-images.results.IMAGE_REF[*])
+      runAfter:
+        - build-images
+      taskRef:
+        params:
+          - name: name
+            value: build-image-index
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:30989fa1f475bb8f6bda811b26bd4ddf7187288ed5815ce634ba399341852c75
+          - name: kind
+            value: task
+        resolver: bundles
+    - name: build-source-image
+      params:
+        - name: BINARY_IMAGE
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: BINARY_IMAGE_DIGEST
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: source-build-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:c35ba219390d77a48ee19347e5ee8d13e5c23e3984299e02291d6da1ed8a986c
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.build-source-image)
+          operator: in
+          values:
+            - "true"
+    - matrix:
+        params:
+          - name: image-platform
+            value:
+              - $(params.build-platforms)
+      name: clair-scan
+      params:
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: clair-scan
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:b01d8e2c58eb407ac23fa07b8e44c4631f0cf7257e87507c829fa2486aff9804
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+    - name: deprecated-base-image-check
+      params:
+        - name: IMAGE_URL
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: deprecated-image-check
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:e3a55ccdf1091b4a35507f9ee2d1918d8e89a5f96babcb5486b491226da03d6f
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+    - name: apply-tags
+      params:
+        - name: IMAGE_URL
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: ADDITIONAL_TAGS
+          value: $(params.additional-tags[*])
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: apply-tags
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:510b6d2a3b188adeb716e49566b57d611ab36bd69a2794b5ddfc11dbf014c2ca
+          - name: kind
+            value: task
+        resolver: bundles
+    - name: validate-fbc
+      params:
+        - name: IMAGE_URL
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: validate-fbc
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:9d3357bdbe3ff76fdc115f3218a1a35ee257712ea2c1a03af62706ff296465dd
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+    - name: fbc-target-index-pruning-check
+      params:
+        - name: IMAGE_URL
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: TARGET_INDEX
+          value: registry.redhat.io/redhat/redhat-operator-index
+        - name: RENDERED_CATALOG_DIGEST
+          value: $(tasks.validate-fbc.results.RENDERED_CATALOG_DIGEST)
+      runAfter:
+        - validate-fbc
+      taskRef:
+        params:
+          - name: name
+            value: fbc-target-index-pruning-check
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:801d678abd0aa49982cafaabd12e50a1614b43849fad973eafda05e512874392
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+  workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true


### PR DESCRIPTION
We are having problems with the fips task in konflux.  It is causing the following error:
```
Inspecting raw image manifest quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-fbc-ocm-4-16-prod@sha256:d574b089c77e807c566e918add8ce6945aa19407e7b230e1acfe03d0d9212cda.
Image manifests are {"amd64":"sha256:285ee56f9d761f9feb4e8fc2681725f2740b6354447e86341b8cc07097218de7","s390x":"sha256:826ad9cd4e43a3775e22157eb7394696cf85204b9c8d175c942a175f68abd045","arm64":"sha256:1d9382024949cc9f4699bdbbeea3a528d0e6e5d9521544230b42da6592b6addb"}
Getting Target ocp version for the FBC fragment
jq: error (at <stdin>:1): Cannot iterate over null (null)
Target OCP version: v4.16
Target index: registry.redhat.io/redhat/redhat-operator-index:v4.16
Rendering FBC fragment: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-fbc-ocm-4-16-prod@sha256:d574b089c77e807c566e918add8ce6945aa19407e7b230e1acfe03d0d9212cda
Getting package names in FBC fragment
Packages in FBC fragment: multicluster-engine
Rendering target index: registry.redhat.io/redhat/redhat-operator-index:v4.16
/utils.sh: xrealloc: cannot allocate 18446744071573084416 bytes
step-fips-operator-check-step-action :-
2026/02/16 15:27:48 Skipping step because a previous step failed
step-parse-images-processed-result :-
2026/02/16 15:27:48 Skipping step because a previous step failed
```
According to konflux-users, removing the task is the current work-around.  We already have an exception in place for fips so I think it will work for handling the missing task.