### PR TITLE
chore: dynamically generate pipeline matrix in bundle update workflow

### DIFF
--- a/.github/workflows/update-tekton-task-bundles.yaml
+++ b/.github/workflows/update-tekton-task-bundles.yaml
@@ -6,17 +6,27 @@ on:
     - cron: "0 0 * * 0" # Runs weekly on Sunday at 00:00 UTC
 
 jobs:
+  generate-matrix:
+    name: Generate pipeline matrix
+    runs-on: ubuntu-latest
+    outputs:
+      pipeline_files: ${{ steps.generate-matrix.outputs.pipeline_files }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Fetch pipeline filenames
+        id: generate-matrix
+        run: |
+          files=$(find pipelines/ -not -type l -type f -exec basename {} +)
+          echo "pipeline_files=$(printf "%s" "$files" | jq -Rs 'split("\n")')" >>"${GITHUB_OUTPUT}"
+
   update-tekton-task-bundles:
+    needs: generate-matrix
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pipeline_file:
-          - common.yaml
-          - common-base.yaml
-          - common-fbc.yaml
-          - common-fbc-nofips.yaml
-          - common-oci-ta.yaml
-          - common-stage.yaml
+        pipeline_file: ${{ fromJson(needs.generate-matrix.outputs.pipeline_files) }}
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,18 +100,7 @@ docker run -it konflux-build-catalog:test /bin/bash
 ## Important Rules
 
 ### Pipeline File Management
-**CRITICAL**: When adding or changing any file in the `pipelines/` directory, you MUST update the `pipeline_file` matrix list in `.github/workflows/update-tekton-task-bundles.yaml` to include the new/changed pipeline file. This ensures the automated bundle update process covers all pipeline files.
-
-Example: If you add `pipelines/new-pipeline.yaml`, update the workflow matrix:
-```yaml
-strategy:
-  matrix:
-    pipeline_file:
-      - common.yaml
-      - common-fbc.yaml
-      - common-oci-ta.yaml
-      - new-pipeline.yaml  # Add new files here
-```
+The `pipeline_file` matrix in `.github/workflows/update-tekton-task-bundles.yaml` is dynamically generated from the `pipelines/` directory (excluding symlinks). New pipeline files are automatically picked up by the workflow without manual matrix updates.
 
 ### Tekton Configuration Synchronization
 **CRITICAL**: Files in `.tekton/` directory are linked to specific pipeline files through the `pipelinesascode.tekton.dev/on-cel-expression` annotation. When adding, renaming, or modifying pipeline files, you MUST ensure the corresponding `.tekton` files reference the correct pipeline file paths.


### PR DESCRIPTION
## Summary
- Replace hardcoded `pipeline_file` matrix with a `generate-matrix` job that discovers pipeline files at runtime using `find`, excluding symlinks
- This eliminates the need to manually update the matrix when adding or removing pipeline files
- Update `CLAUDE.md` to reflect the dynamic matrix approach

## Test plan
- [ ] Verify the workflow YAML is valid
- [ ] Confirm the `generate-matrix` job correctly discovers all non-symlink pipeline files in `pipelines/`
- [ ] Verify symlinks (e.g., `common_mce_*.yaml`) are excluded from the matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)