### PR TITLE
fix: use \; instead of + in find -exec basename

### DIFF
--- a/.github/workflows/update-tekton-task-bundles.yaml
+++ b/.github/workflows/update-tekton-task-bundles.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Fetch pipeline filenames
         id: generate-matrix
         run: |
-          files=$(find pipelines/ -not -type l -type f -exec basename {} +)
+          files=$(find pipelines/ -not -type l -type f -exec basename {} \;)
           echo "pipeline_files=$(printf "%s" "$files" | jq -Rs 'split("\n")')" >>"${GITHUB_OUTPUT}"
 
   update-tekton-task-bundles:


### PR DESCRIPTION
## Summary
- Fix `basename: extra operand` error in the `update-tekton-task-bundles` workflow by changing `-exec basename {} +` to `-exec basename {} \;`
- The `+` variant batches multiple filenames into a single `basename` call, but `basename` only accepts one operand, causing the workflow to fail when multiple pipeline files exist

## Related
- Failed action run: https://github.com/stolostron/konflux-build-catalog/actions/runs/22531930184/job/65272519417

## Test plan
- [ ] Verify the `update-tekton-task-bundles` workflow runs successfully after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)