### PR TITLE
fix: update KubeOpenCode agentRef name from fast to acm

### DIFF
--- a/.github/workflows/update-tekton-task-bundles.yaml
+++ b/.github/workflows/update-tekton-task-bundles.yaml
@@ -277,7 +277,7 @@ jobs:
           spec:
             # Reference the agent that will execute tasks created from this template
             agentRef:
-              name: fast
+              name: acm
             # Contexts that will be merged with task-specific contexts
             contexts:
               - name: bot-instructions


### PR DESCRIPTION
## Summary
- Update the KubeOpenCode `agentRef.name` from `fast` to `acm` in the migration task creation workflow, as the agent has been renamed.

## Test plan
- [ ] Verify the workflow YAML is valid
- [ ] Confirm the `acm` agent exists in the KubeOpenCode cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)