### PR TITLE
feat: add script to sync with upstream pipelines

### DIFF
--- a/.github/workflows/update-tekton-task-bundles.yaml
+++ b/.github/workflows/update-tekton-task-bundles.yaml
@@ -52,6 +52,24 @@ jobs:
         run: |
           ./build/update-task-refs.sh pipelines/${{ matrix.pipeline_file }}
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+          cache: pip
+
+      - name: Sync pipeline config with upstream
+        id: sync_upstream
+        run: |
+          pip install -r requirements.txt
+          python sync_upstream_pipeline.py pipelines/${{ matrix.pipeline_file }} ||
+            exit_code=$?
+          if [[ "${exit_code}" == 200 ]]; then
+            echo "new_configuration=true" >> $GITHUB_OUTPUT
+          else
+            exit "${exit_code}"
+          fi
+
       - name: Check if migration is required
         id: check_migration
         run: |
@@ -90,7 +108,7 @@ jobs:
           fi
 
       - name: Extract pipeline filename without extension
-        if: steps.check_migration.outputs.migration_required == 'true'
+        if: steps.check_migration.outputs.migration_required == 'true' || steps.sync_upstream.outputs.new_configuration == 'true'
         id: extract_filename
         run: |
           filename="${{ matrix.pipeline_file }}"
@@ -100,7 +118,7 @@ jobs:
           echo "filename_label=${filename_label}" >> $GITHUB_OUTPUT
 
       - name: Check for existing migration issue
-        if: steps.check_migration.outputs.migration_required == 'true'
+        if: steps.check_migration.outputs.migration_required == 'true' || steps.sync_upstream.outputs.new_configuration == 'true'
         id: check_existing_issue
         env:
           GH_TOKEN: ${{ github.token }}
@@ -124,12 +142,12 @@ jobs:
           fi
 
       - name: Create issue for migration
-        if: steps.check_migration.outputs.migration_required == 'true' && steps.check_existing_issue.outputs.issue_exists == 'false'
+        if: (steps.check_migration.outputs.migration_required == 'true' || steps.sync_upstream.outputs.new_configuration == 'true') && steps.check_existing_issue.outputs.issue_exists == 'false'
         uses: imjohnbo/issue-bot@v3
         with:
           token: ${{ github.token }}
           title: "Tekton Task Bundle Migration Required - ${{ matrix.pipeline_file }} - ${{ github.run_id }}"
-          body: ${{ steps.check_migration.outputs.issue_body }}
+          body: ${{ steps.check_migration.outputs.issue_body || 'New configuration detected for ${{ matrix.pipeline_file }} requiring manual review' }}
           labels: "migration, ${{ steps.extract_filename.outputs.filename_label }}"
           assignees: ${{ github.actor }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ merged_migration_data.json
 *.swo
 *~
 
+# Python
+__pycache__/
+.venv/
+
 # OS generated files
 .DS_Store
 .DS_Store?

--- a/README.md
+++ b/README.md
@@ -206,6 +206,27 @@ yq eval pipelines/common.yaml > /dev/null
 for file in pipelines/*.yaml; do yq eval "$file" > /dev/null && echo "$file: OK"; done
 ```
 
+### Sync Upstream Pipelines
+
+```bash
+# Sync all pipelines from konflux-ci/build-definitions
+python3 sync_upstream_pipeline.py
+
+# Sync a specific pipeline file
+python3 sync_upstream_pipeline.py pipelines/common.yaml
+
+# Dry-run to preview changes without writing
+python3 sync_upstream_pipeline.py --dry-run
+```
+
+The [`sync_upstream_pipeline.py`](./sync_upstream_pipeline.py) script synchronizes local pipeline files with their upstream counterparts from [konflux-ci/build-definitions](https://github.com/konflux-ci/build-definitions) while preserving local customizations. It's configured using the [`upstream-map.yaml`](./upstream-map.yaml).
+
+**Exit codes:**
+
+- `0` - No changes detected
+- `200` - At least one pipeline file was updated
+- `1` - Error occurred (e.g., missing mapped file)
+
 ## Important Rules
 
 ### Pipeline File Management

--- a/pipelines/common-base.yaml
+++ b/pipelines/common-base.yaml
@@ -12,19 +12,6 @@ spec:
     - description: Source Repository URL
       name: git-url
       type: string
-    - default: "1"
-      name: depth
-      description: Perform a shallow clone, fetching only the most recent
-        N commits.
-      type: string
-    - default: "false"
-      name: fetchTags
-      description: Fetch all tags for the repo.
-      type: string
-    - default: ""
-      name: refspec
-      description: Refspec to fetch before checking out revision.
-      type: string
     - default: ""
       description: Revision of the Source Repository
       name: revision
@@ -32,10 +19,6 @@ spec:
     - description: Fully Qualified Output Image
       name: output-image
       type: string
-    - default: []
-      description: Additional tags to add to the image
-      name: additional-tags
-      type: array
     - default: .
       description: Path to the source code of an application's component from where to build image.
       name: path-context
@@ -43,10 +26,6 @@ spec:
     - default: Dockerfile
       description: Path to the Dockerfile inside the context specified by parameter path-context
       name: dockerfile
-      type: string
-    - default: "false"
-      description: Force rebuild image
-      name: rebuild
       type: string
     - default: "false"
       description: Skip checks against built image
@@ -57,7 +36,7 @@ spec:
       name: hermetic
       type: string
     - default: ""
-      description: Build dependencies to be prefetched by Cachi2
+      description: Build dependencies to be prefetched
       name: prefetch-input
       type: string
     - default: ""
@@ -72,6 +51,14 @@ spec:
       description: Add built image into an OCI image index
       name: build-image-index
       type: string
+    - name: buildah-format
+      default: docker
+      type: string
+      description: The format for the resulting image's mediaType. Valid values are oci or docker.
+    - name: enable-cache-proxy
+      default: 'false'
+      description: Enable cache proxy configuration
+      type: string
     - default: []
       description: Array of --build-arg values ("arg=value" strings) for buildah
       name: build-args
@@ -81,7 +68,7 @@ spec:
       name: build-args-file
       type: string
     - default: 'false'
-      description: 'Whether to enable privileged mode, should be used only with remote VMs'
+      description: Whether to enable privileged mode, should be used only with remote VMs
       name: privileged-nested
       type: string
     - default:
@@ -92,6 +79,22 @@ spec:
       description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array
+    - default: "1"
+      name: depth
+      description: Perform a shallow clone, fetching only the most recent N commits.
+      type: string
+    - default: "false"
+      name: fetchTags
+      description: Fetch all tags for the repo.
+      type: string
+    - default: ""
+      name: refspec
+      description: Refspec to fetch before checking out revision.
+      type: string
+    - default: []
+      description: Additional tags to add to the image
+      name: additional-tags
+      type: array
     - default: 'true'
       description: Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.
       name: enable-symlink-check
@@ -100,7 +103,7 @@ spec:
       description: Whether to send slack notification when the pipeline run failed
       name: send-slack-notification
       type: string
-    - default: "" # Need to change for each release, empty for non-release
+    - default: ""
       name: konflux-application-name
       description: The name of the application in Konflux, this is required when send-slack-notification is true
       type: string
@@ -130,14 +133,6 @@ spec:
       name: slack-group-id
       description: |
         The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
-    - name: buildah-format
-      default: docker
-      type: string
-      description: The format for the resulting image's mediaType. Valid values are oci or docker.
-    - name: enable-cache-proxy
-      default: 'false'
-      description: Enable cache proxy configuration
-      type: string
   results:
     - description: ""
       name: IMAGE_URL
@@ -174,18 +169,18 @@ spec:
       params:
         - name: url
           value: $(params.git-url)
-        - name: depth
-          value: $(params.depth)
-        - name: fetchTags
-          value: $(params.fetchTags)
-        - name: refspec
-          value: $(params.refspec)
         - name: revision
           value: $(params.revision)
         - name: ociStorage
           value: $(params.output-image).git
         - name: ociArtifactExpiresAfter
           value: $(params.image-expires-after)
+        - name: depth
+          value: $(params.depth)
+        - name: fetchTags
+          value: $(params.fetchTags)
+        - name: refspec
+          value: $(params.refspec)
         - name: enableSymlinkCheck
           value: $(params.enable-symlink-check)
       runAfter:
@@ -256,14 +251,20 @@ spec:
           value: $(params.build-args-file)
         - name: PRIVILEGED_NESTED
           value: $(params.privileged-nested)
+        - name: SOURCE_URL
+          value: $(tasks.clone-repository.results.url)
+        - name: BUILDAH_FORMAT
+          value: $(params.buildah-format)
+        - name: HTTP_PROXY
+          value: $(tasks.init.results.http-proxy)
+        - name: NO_PROXY
+          value: $(tasks.init.results.no-proxy)
         - name: SOURCE_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
         - name: CACHI2_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
         - name: IMAGE_APPEND_PLATFORM
-          value: "true"
-        - name: BUILDAH_FORMAT
-          value: $(params.buildah-format)
+          value: 'true'
       runAfter:
         - prefetch-dependencies
       taskRef:
@@ -326,7 +327,7 @@ spec:
         - input: $(params.build-source-image)
           operator: in
           values:
-            - "true"
+            - 'true'
     - name: deprecated-base-image-check
       params:
         - name: IMAGE_URL
@@ -348,7 +349,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - matrix:
         params:
           - name: image-platform
@@ -375,8 +376,13 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
-    - name: ecosystem-cert-preflight-checks
+            - 'false'
+    - matrix:
+        params:
+          - name: platform
+            value:
+              - $(params.build-platforms)
+      name: ecosystem-cert-preflight-checks
       params:
         - name: image-url
           value: $(tasks.build-image-index.results.IMAGE_URL)
@@ -395,7 +401,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: sast-snyk-check
       params:
         - name: image-digest
@@ -421,13 +427,13 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
-    - name: clamav-scan
-      matrix:
+            - 'false'
+    - matrix:
         params:
           - name: image-arch
             value:
               - $(params.build-platforms)
+      name: clamav-scan
       params:
         - name: image-digest
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)
@@ -448,13 +454,13 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: sast-coverity-check
       params:
-        - name: image-url
-          value: $(tasks.build-image-index.results.IMAGE_URL)
         - name: image-digest
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
         - name: IMAGE
           value: $(params.output-image)
         - name: DOCKERFILE
@@ -493,7 +499,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
         - input: $(tasks.coverity-availability-check.results.STATUS)
           operator: in
           values:
@@ -514,7 +520,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: sast-shell-check
       params:
         - name: image-digest
@@ -540,7 +546,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: sast-unicode-check
       params:
         - name: image-digest
@@ -566,7 +572,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: apply-tags
       params:
         - name: IMAGE_URL
@@ -630,21 +636,8 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
   finally:
-    - name: show-sbom
-      params:
-        - name: IMAGE_URL
-          value: $(tasks.build-image-index.results.IMAGE_URL)
-      taskRef:
-        params:
-          - name: name
-            value: show-sbom
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:04994df487ee886adbe60a8a5866647fbdfd53cc26f7b2554272ba51bf7af29e
-          - name: kind
-            value: task
-        resolver: bundles
     - name: slack-webhook-notification
       params:
         - name: message

--- a/pipelines/common-fbc-nofips.yaml
+++ b/pipelines/common-fbc-nofips.yaml
@@ -10,19 +10,6 @@ spec:
     _Uses `buildah` to create a container image. Its build-time tests are limited to verifying the included catalog and do not scan the image.
     This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-fbc-builder?tab=tags)_
   finally:
-    - name: show-sbom
-      params:
-        - name: IMAGE_URL
-          value: $(tasks.build-image-index.results.IMAGE_URL)
-      taskRef:
-        params:
-          - name: name
-            value: show-sbom
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:04994df487ee886adbe60a8a5866647fbdfd53cc26f7b2554272ba51bf7af29e
-          - name: kind
-            value: task
-        resolver: bundles
     - name: slack-webhook-notification
       params:
         - name: message
@@ -70,25 +57,13 @@ spec:
     - description: Fully Qualified Output Image
       name: output-image
       type: string
-    - default: []
-      description: Additional tags to add to the image
-      name: additional-tags
-      type: array
     - default: .
-      description:
-        Path to the source code of an application's component from where
-        to build image.
+      description: Path to the source code of an application's component from where to build image.
       name: path-context
       type: string
     - default: Dockerfile
-      description:
-        Path to the Dockerfile inside the context specified by parameter
-        path-context
+      description: Path to the Dockerfile inside the context specified by parameter path-context
       name: dockerfile
-      type: string
-    - default: "false"
-      description: Force rebuild image
-      name: rebuild
       type: string
     - default: "false"
       description: Skip checks against built image
@@ -99,22 +74,20 @@ spec:
       name: hermetic
       type: string
     - default: ""
-      description: Build dependencies to be prefetched by Cachi2
+      description: Build dependencies to be prefetched
       name: prefetch-input
       type: string
     - default: ""
-      description:
-        Image tag expiration time, time values could be something like
-        1h, 2d, 3w for hours, days, and weeks, respectively.
+      description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-      type: string
-    - default: "true"
-      description: Build a source image.
-      name: build-source-image
       type: string
     - default: "true"
       description: Add built image into an OCI image index
       name: build-image-index
+      type: string
+    - name: enable-cache-proxy
+      default: "false"
+      description: Enable cache proxy configuration
       type: string
     - default: []
       description: Array of --build-arg values ("arg=value" strings) for buildah
@@ -126,10 +99,12 @@ spec:
       type: string
     - default:
         - linux/x86_64
-      description:
-        List of platforms to build the container images on. The available
-        set of values is determined by the configuration of the multi-platform-controller.
+      description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
+      type: array
+    - default: []
+      description: Additional tags to add to the image
+      name: additional-tags
       type: array
     - default: []
       description: An array of arguments passed to opm when executed.
@@ -147,7 +122,7 @@ spec:
       description: Whether to send slack notification when the pipeline run failed
       name: send-slack-notification
       type: string
-    - default: "" # Need to change for each release, empty for non-release
+    - default: ""
       name: konflux-application-name
       description: The name of the application in Konflux, this is required when send-slack-notification is true
       type: string
@@ -177,10 +152,6 @@ spec:
       name: slack-group-id
       description: |
         The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
-    - name: enable-cache-proxy
-      default: "false"
-      description: Enable cache proxy configuration
-      type: string
   results:
     - description: ""
       name: IMAGE_URL
@@ -310,12 +281,18 @@ spec:
             - $(params.build-args[*])
         - name: BUILD_ARGS_FILE
           value: $(params.build-args-file)
+        - name: SOURCE_URL
+          value: $(tasks.clone-repository.results.url)
+        - name: HTTP_PROXY
+          value: $(tasks.init.results.http-proxy)
+        - name: NO_PROXY
+          value: $(tasks.init.results.no-proxy)
         - name: SOURCE_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
         - name: CACHI2_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
         - name: IMAGE_APPEND_PLATFORM
-          value: "true"
+          value: 'true'
       runAfter:
         - clone-repository
       taskRef:
@@ -351,59 +328,6 @@ spec:
           - name: kind
             value: task
         resolver: bundles
-    - name: build-source-image
-      params:
-        - name: BINARY_IMAGE
-          value: $(tasks.build-image-index.results.IMAGE_URL)
-        - name: BINARY_IMAGE_DIGEST
-          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-        - name: SOURCE_ARTIFACT
-          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-        - name: CACHI2_ARTIFACT
-          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      runAfter:
-        - build-image-index
-      taskRef:
-        params:
-          - name: name
-            value: source-build-oci-ta
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:362f0475df00e7dfb5f15dea0481d1b68b287f60411718d70a23da3c059a5613
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(params.build-source-image)
-          operator: in
-          values:
-            - "true"
-    - matrix:
-        params:
-          - name: image-platform
-            value:
-              - $(params.build-platforms)
-      name: clair-scan
-      params:
-        - name: image-digest
-          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-        - name: image-url
-          value: $(tasks.build-image-index.results.IMAGE_URL)
-      runAfter:
-        - build-image-index
-      taskRef:
-        params:
-          - name: name
-            value: clair-scan
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3.2@sha256:3fa03be0280f33d7070ea53f26d53e727199737a7a2b9a59a95071ae40a999ac
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(params.skip-checks)
-          operator: in
-          values:
-            - "false"
     - name: deprecated-base-image-check
       params:
         - name: IMAGE_URL
@@ -425,7 +349,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: apply-tags
       params:
         - name: IMAGE_URL
@@ -466,7 +390,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: fbc-target-index-pruning-check
       params:
         - name: IMAGE_URL

--- a/pipelines/common-fbc-nofips.yaml
+++ b/pipelines/common-fbc-nofips.yaml
@@ -492,7 +492,29 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
+    - name: fbc-fips-check-oci-ta
+      params:
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+        - build-image-index
+      taskRef:
+        name: fbc-fips-check-oci-ta
+        version: '0.1'
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - 'false'
+        - input: 'false'
+          operator: in
+          values:
+            - 'true'
   workspaces:
     - name: git-auth
       optional: true

--- a/pipelines/common-fbc.yaml
+++ b/pipelines/common-fbc.yaml
@@ -9,19 +9,6 @@ spec:
     _Uses `buildah` to create a container image. Its build-time tests are limited to verifying the included catalog and do not scan the image.
     This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-fbc-builder?tab=tags)_
   finally:
-    - name: show-sbom
-      params:
-        - name: IMAGE_URL
-          value: $(tasks.build-image-index.results.IMAGE_URL)
-      taskRef:
-        params:
-          - name: name
-            value: show-sbom
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:04994df487ee886adbe60a8a5866647fbdfd53cc26f7b2554272ba51bf7af29e
-          - name: kind
-            value: task
-        resolver: bundles
     - name: slack-webhook-notification
       params:
         - name: message
@@ -69,25 +56,13 @@ spec:
     - description: Fully Qualified Output Image
       name: output-image
       type: string
-    - default: []
-      description: Additional tags to add to the image
-      name: additional-tags
-      type: array
     - default: .
-      description:
-        Path to the source code of an application's component from where
-        to build image.
+      description: Path to the source code of an application's component from where to build image.
       name: path-context
       type: string
     - default: Dockerfile
-      description:
-        Path to the Dockerfile inside the context specified by parameter
-        path-context
+      description: Path to the Dockerfile inside the context specified by parameter path-context
       name: dockerfile
-      type: string
-    - default: "false"
-      description: Force rebuild image
-      name: rebuild
       type: string
     - default: "false"
       description: Skip checks against built image
@@ -98,22 +73,20 @@ spec:
       name: hermetic
       type: string
     - default: ""
-      description: Build dependencies to be prefetched by Cachi2
+      description: Build dependencies to be prefetched
       name: prefetch-input
       type: string
     - default: ""
-      description:
-        Image tag expiration time, time values could be something like
-        1h, 2d, 3w for hours, days, and weeks, respectively.
+      description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-      type: string
-    - default: "true"
-      description: Build a source image.
-      name: build-source-image
       type: string
     - default: "true"
       description: Add built image into an OCI image index
       name: build-image-index
+      type: string
+    - name: enable-cache-proxy
+      default: "false"
+      description: Enable cache proxy configuration
       type: string
     - default: []
       description: Array of --build-arg values ("arg=value" strings) for buildah
@@ -125,10 +98,12 @@ spec:
       type: string
     - default:
         - linux/x86_64
-      description:
-        List of platforms to build the container images on. The available
-        set of values is determined by the configuration of the multi-platform-controller.
+      description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
+      type: array
+    - default: []
+      description: Additional tags to add to the image
+      name: additional-tags
       type: array
     - default: []
       description: An array of arguments passed to opm when executed.
@@ -150,7 +125,7 @@ spec:
       description: Whether to send slack notification when the pipeline run failed
       name: send-slack-notification
       type: string
-    - default: "" # Need to change for each release, empty for non-release
+    - default: ""
       name: konflux-application-name
       description: The name of the application in Konflux, this is required when send-slack-notification is true
       type: string
@@ -180,10 +155,6 @@ spec:
       name: slack-group-id
       description: |
         The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
-    - name: enable-cache-proxy
-      default: "false"
-      description: Enable cache proxy configuration
-      type: string
   results:
     - description: ""
       name: IMAGE_URL
@@ -313,12 +284,18 @@ spec:
             - $(params.build-args[*])
         - name: BUILD_ARGS_FILE
           value: $(params.build-args-file)
+        - name: SOURCE_URL
+          value: $(tasks.clone-repository.results.url)
+        - name: HTTP_PROXY
+          value: $(tasks.init.results.http-proxy)
+        - name: NO_PROXY
+          value: $(tasks.init.results.no-proxy)
         - name: SOURCE_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
         - name: CACHI2_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
         - name: IMAGE_APPEND_PLATFORM
-          value: "true"
+          value: 'true'
       runAfter:
         - clone-repository
       taskRef:
@@ -354,59 +331,6 @@ spec:
           - name: kind
             value: task
         resolver: bundles
-    - name: build-source-image
-      params:
-        - name: BINARY_IMAGE
-          value: $(tasks.build-image-index.results.IMAGE_URL)
-        - name: BINARY_IMAGE_DIGEST
-          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-        - name: SOURCE_ARTIFACT
-          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-        - name: CACHI2_ARTIFACT
-          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      runAfter:
-        - build-image-index
-      taskRef:
-        params:
-          - name: name
-            value: source-build-oci-ta
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:362f0475df00e7dfb5f15dea0481d1b68b287f60411718d70a23da3c059a5613
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(params.build-source-image)
-          operator: in
-          values:
-            - "true"
-    - matrix:
-        params:
-          - name: image-platform
-            value:
-              - $(params.build-platforms)
-      name: clair-scan
-      params:
-        - name: image-digest
-          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-        - name: image-url
-          value: $(tasks.build-image-index.results.IMAGE_URL)
-      runAfter:
-        - build-image-index
-      taskRef:
-        params:
-          - name: name
-            value: clair-scan
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3.2@sha256:3fa03be0280f33d7070ea53f26d53e727199737a7a2b9a59a95071ae40a999ac
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(params.skip-checks)
-          operator: in
-          values:
-            - "false"
     - name: deprecated-base-image-check
       params:
         - name: IMAGE_URL
@@ -428,7 +352,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: apply-tags
       params:
         - name: IMAGE_URL
@@ -469,7 +393,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: fbc-target-index-pruning-check
       params:
         - name: IMAGE_URL
@@ -495,7 +419,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: fbc-fips-check-oci-ta
       params:
         - name: image-digest

--- a/pipelines/common-fbc.yaml
+++ b/pipelines/common-fbc.yaml
@@ -143,6 +143,10 @@ spec:
       name: idms-path
       type: string
     - default: "false"
+      description: Whether to skip FIPS checks
+      name: skip-fips-check
+      type: string
+    - default: "false"
       description: Whether to send slack notification when the pipeline run failed
       name: send-slack-notification
       type: string
@@ -515,7 +519,11 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
+        - input: $(params.skip-fips-check)
+          operator: in
+          values:
+            - 'false'
   workspaces:
     - name: git-auth
       optional: true

--- a/pipelines/common-oci-ta.yaml
+++ b/pipelines/common-oci-ta.yaml
@@ -9,19 +9,6 @@ spec:
     _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
     This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
   finally:
-    - name: show-sbom
-      params:
-        - name: IMAGE_URL
-          value: $(tasks.build-image-index.results.IMAGE_URL)
-      taskRef:
-        params:
-          - name: name
-            value: show-sbom
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:04994df487ee886adbe60a8a5866647fbdfd53cc26f7b2554272ba51bf7af29e
-          - name: kind
-            value: task
-        resolver: bundles
     - name: slack-webhook-notification
       params:
         - name: message
@@ -69,10 +56,6 @@ spec:
     - description: Fully Qualified Output Image
       name: output-image
       type: string
-    - default: []
-      description: Additional tags to add to the image
-      name: additional-tags
-      type: array
     - default: .
       description: Path to the source code of an application's component from where to build image.
       name: path-context
@@ -80,10 +63,6 @@ spec:
     - default: Dockerfile
       description: Path to the Dockerfile inside the context specified by parameter path-context
       name: dockerfile
-      type: string
-    - default: "false"
-      description: Force rebuild image
-      name: rebuild
       type: string
     - default: "false"
       description: Skip checks against built image
@@ -94,12 +73,13 @@ spec:
       name: hermetic
       type: string
     - default: ""
-      description: Build dependencies to be prefetched by Cachi2
+      description: Build dependencies to be prefetched
       name: prefetch-input
       type: string
     - default: ""
       description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+      type: string
     - default: "true"
       description: Build a source image.
       name: build-source-image
@@ -107,6 +87,14 @@ spec:
     - default: "false"
       description: Add built image into an OCI image index
       name: build-image-index
+      type: string
+    - name: buildah-format
+      default: docker
+      type: string
+      description: The format for the resulting image's mediaType. Valid values are oci or docker.
+    - name: enable-cache-proxy
+      default: 'false'
+      description: Enable cache proxy configuration
       type: string
     - default: []
       description: Array of --build-arg values ("arg=value" strings) for buildah
@@ -120,11 +108,15 @@ spec:
       description: Whether to enable privileged mode, should be used only with remote VMs
       name: privileged-nested
       type: string
+    - default: []
+      description: Additional tags to add to the image
+      name: additional-tags
+      type: array
     - default: "false"
       description: Whether to send slack notification when the pipeline run failed
       name: send-slack-notification
       type: string
-    - default: ""  # Need to change for each release, empty for non-release
+    - default: ""
       name: konflux-application-name
       description: The name of the application in Konflux, this is required when send-slack-notification is true
       type: string
@@ -154,14 +146,6 @@ spec:
       name: slack-group-id
       description: |
         The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
-    - name: buildah-format
-      default: docker
-      type: string
-      description: The format for the resulting image's mediaType. Valid values are oci or docker.
-    - name: enable-cache-proxy
-      default: 'false'
-      description: Enable cache proxy configuration
-      type: string
   results:
     - description: ""
       name: IMAGE_URL
@@ -262,12 +246,18 @@ spec:
           value: $(params.build-args-file)
         - name: PRIVILEGED_NESTED
           value: $(params.privileged-nested)
+        - name: SOURCE_URL
+          value: $(tasks.clone-repository.results.url)
+        - name: BUILDAH_FORMAT
+          value: $(params.buildah-format)
+        - name: HTTP_PROXY
+          value: $(tasks.init.results.http-proxy)
+        - name: NO_PROXY
+          value: $(tasks.init.results.no-proxy)
         - name: SOURCE_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
         - name: CACHI2_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-        - name: BUILDAH_FORMAT
-          value: $(params.buildah-format)
       runAfter:
         - prefetch-dependencies
       taskRef:
@@ -309,12 +299,12 @@ spec:
       params:
         - name: BINARY_IMAGE
           value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: BINARY_IMAGE_DIGEST
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
         - name: SOURCE_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
         - name: CACHI2_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-        - name: BINARY_IMAGE_DIGEST
-          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
         - build-image-index
       taskRef:
@@ -330,7 +320,7 @@ spec:
         - input: $(params.build-source-image)
           operator: in
           values:
-            - "true"
+            - 'true'
     - name: deprecated-base-image-check
       params:
         - name: IMAGE_URL
@@ -352,7 +342,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: clair-scan
       params:
         - name: image-digest
@@ -374,7 +364,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: ecosystem-cert-preflight-checks
       params:
         - name: image-url
@@ -394,7 +384,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: sast-snyk-check
       params:
         - name: image-digest
@@ -420,7 +410,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: clamav-scan
       params:
         - name: image-digest
@@ -442,7 +432,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: sast-coverity-check
       params:
         - name: image-digest
@@ -487,7 +477,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
         - input: $(tasks.coverity-availability-check.results.STATUS)
           operator: in
           values:
@@ -508,7 +498,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: sast-shell-check
       params:
         - name: image-digest
@@ -534,7 +524,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: sast-unicode-check
       params:
         - name: image-digest
@@ -560,7 +550,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: apply-tags
       params:
         - name: IMAGE_URL
@@ -624,7 +614,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
   workspaces:
     - name: git-auth
       optional: true

--- a/pipelines/common-stage.yaml
+++ b/pipelines/common-stage.yaml
@@ -16,10 +16,6 @@ spec:
     - description: Fully Qualified Output Image
       name: output-image
       type: string
-    - default: []
-      description: Additional tags to add to the image
-      name: additional-tags
-      type: array
     - default: .
       description: Path to the source code of an application's component from where to build image.
       name: path-context
@@ -27,10 +23,6 @@ spec:
     - default: Dockerfile
       description: Path to the Dockerfile inside the context specified by parameter path-context
       name: dockerfile
-      type: string
-    - default: "false"
-      description: Force rebuild image
-      name: rebuild
       type: string
     - default: "false"
       description: Skip checks against built image
@@ -41,7 +33,7 @@ spec:
       name: hermetic
       type: string
     - default: ""
-      description: Build dependencies to be prefetched by Cachi2
+      description: Build dependencies to be prefetched
       name: prefetch-input
       type: string
     - default: ""
@@ -56,6 +48,14 @@ spec:
       description: Add built image into an OCI image index
       name: build-image-index
       type: string
+    - name: buildah-format
+      default: docker
+      type: string
+      description: The format for the resulting image's mediaType. Valid values are oci or docker.
+    - name: enable-cache-proxy
+      default: "false"
+      description: Enable cache proxy configuration
+      type: string
     - default: []
       description: Array of --build-arg values ("arg=value" strings) for buildah
       name: build-args
@@ -65,7 +65,7 @@ spec:
       name: build-args-file
       type: string
     - default: "false"
-      description: "Whether to enable privileged mode, should be used only with remote VMs"
+      description: Whether to enable privileged mode, should be used only with remote VMs
       name: privileged-nested
       type: string
     - default:
@@ -75,6 +75,10 @@ spec:
         - linux/s390x
       description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
+      type: array
+    - default: []
+      description: Additional tags to add to the image
+      name: additional-tags
       type: array
     - default: "true"
       description: Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.
@@ -110,14 +114,6 @@ spec:
       name: slack-group-id
       description: |
         The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
-    - name: buildah-format
-      default: docker
-      type: string
-      description: The format for the resulting image's mediaType. Valid values are oci or docker.
-    - name: enable-cache-proxy
-      default: "false"
-      description: Enable cache proxy configuration
-      type: string
   results:
     - description: ""
       name: IMAGE_URL
@@ -150,7 +146,6 @@ spec:
           - name: kind
             value: task
         resolver: bundles
-
     - name: clone-repository
       params:
         - name: url
@@ -177,7 +172,6 @@ spec:
       workspaces:
         - name: basic-auth
           workspace: git-auth
-
     - name: fetch-product-metadata
       params:
         - name: output-image
@@ -193,7 +187,6 @@ spec:
           - name: pathInRepo
             value: tasks/fetch-product-metadata/fetch-product-metadata.yaml
         resolver: git
-
     - name: prefetch-dependencies
       params:
         - name: input
@@ -220,7 +213,6 @@ spec:
           workspace: git-auth
         - name: netrc
           workspace: netrc
-
     - matrix:
         params:
           - name: PLATFORM
@@ -246,24 +238,29 @@ spec:
           value:
             - $(params.build-args[*])
             - MCE_VERSION=v$(tasks.fetch-product-metadata.results.z-stream-version)
-        - name: LABELS
-          value:
-            - $(tasks.fetch-product-metadata.results.image-labels[*])
         - name: BUILD_ARGS_FILE
           value: $(params.build-args-file)
         - name: PRIVILEGED_NESTED
           value: $(params.privileged-nested)
+        - name: SOURCE_URL
+          value: $(tasks.clone-repository.results.url)
+        - name: BUILDAH_FORMAT
+          value: $(params.buildah-format)
+        - name: HTTP_PROXY
+          value: $(tasks.init.results.http-proxy)
+        - name: NO_PROXY
+          value: $(tasks.init.results.no-proxy)
         - name: SOURCE_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
         - name: CACHI2_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
         - name: IMAGE_APPEND_PLATFORM
-          value: "true"
-        - name: BUILDAH_FORMAT
-          value: $(params.buildah-format)
+          value: 'true'
+        - name: LABELS
+          value:
+            - $(tasks.fetch-product-metadata.results.image-labels[*])
       runAfter:
         - prefetch-dependencies
-        - fetch-product-metadata
       taskRef:
         params:
           - name: name
@@ -273,7 +270,6 @@ spec:
           - name: kind
             value: task
         resolver: bundles
-
     - name: build-image-index
       params:
         - name: IMAGE
@@ -300,7 +296,6 @@ spec:
           - name: kind
             value: task
         resolver: bundles
-
     - name: build-source-image
       params:
         - name: BINARY_IMAGE
@@ -326,8 +321,7 @@ spec:
         - input: $(params.build-source-image)
           operator: in
           values:
-            - "true"
-
+            - 'true'
     - name: deprecated-base-image-check
       params:
         - name: IMAGE_URL
@@ -349,8 +343,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
-
+            - 'false'
     - matrix:
         params:
           - name: image-platform
@@ -377,9 +370,13 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
-
-    - name: ecosystem-cert-preflight-checks
+            - 'false'
+    - matrix:
+        params:
+          - name: platform
+            value:
+              - $(params.build-platforms)
+      name: ecosystem-cert-preflight-checks
       params:
         - name: image-url
           value: $(tasks.build-image-index.results.IMAGE_URL)
@@ -398,8 +395,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
-
+            - 'false'
     - name: sast-snyk-check
       params:
         - name: image-digest
@@ -425,14 +421,13 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
-
-    - name: clamav-scan
-      matrix:
+            - 'false'
+    - matrix:
         params:
           - name: image-arch
             value:
               - $(params.build-platforms)
+      name: clamav-scan
       params:
         - name: image-digest
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)
@@ -453,14 +448,13 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
-
+            - 'false'
     - name: sast-coverity-check
       params:
-        - name: image-url
-          value: $(tasks.build-image-index.results.IMAGE_URL)
         - name: image-digest
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
         - name: IMAGE
           value: $(params.output-image)
         - name: DOCKERFILE
@@ -499,12 +493,11 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
         - input: $(tasks.coverity-availability-check.results.STATUS)
           operator: in
           values:
             - success
-
     - name: coverity-availability-check
       runAfter:
         - build-image-index
@@ -521,8 +514,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
-
+            - 'false'
     - name: sast-shell-check
       params:
         - name: image-digest
@@ -548,8 +540,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
-
+            - 'false'
     - name: sast-unicode-check
       params:
         - name: image-digest
@@ -575,8 +566,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
-
+            - 'false'
     - name: apply-tags
       params:
         - name: IMAGE_URL
@@ -596,7 +586,6 @@ spec:
           - name: kind
             value: task
         resolver: bundles
-
     - name: push-dockerfile
       params:
         - name: IMAGE
@@ -620,7 +609,6 @@ spec:
           - name: kind
             value: task
         resolver: bundles
-
     - name: rpms-signature-scan
       params:
         - name: image-url
@@ -642,22 +630,8 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
-
+            - 'false'
   finally:
-    - name: show-sbom
-      params:
-        - name: IMAGE_URL
-          value: $(tasks.build-image-index.results.IMAGE_URL)
-      taskRef:
-        params:
-          - name: name
-            value: show-sbom
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:04994df487ee886adbe60a8a5866647fbdfd53cc26f7b2554272ba51bf7af29e
-          - name: kind
-            value: task
-        resolver: bundles
     - name: slack-webhook-notification
       params:
         - name: message

--- a/pipelines/common.yaml
+++ b/pipelines/common.yaml
@@ -12,19 +12,6 @@ spec:
     - description: Source Repository URL
       name: git-url
       type: string
-    - default: "1"
-      name: depth
-      description: Perform a shallow clone, fetching only the most recent
-        N commits.
-      type: string
-    - default: "false"
-      name: fetchTags
-      description: Fetch all tags for the repo.
-      type: string
-    - default: ""
-      name: refspec
-      description: Refspec to fetch before checking out revision.
-      type: string
     - default: ""
       description: Revision of the Source Repository
       name: revision
@@ -32,10 +19,6 @@ spec:
     - description: Fully Qualified Output Image
       name: output-image
       type: string
-    - default: []
-      description: Additional tags to add to the image
-      name: additional-tags
-      type: array
     - default: .
       description: Path to the source code of an application's component from where to build image.
       name: path-context
@@ -43,10 +26,6 @@ spec:
     - default: Dockerfile
       description: Path to the Dockerfile inside the context specified by parameter path-context
       name: dockerfile
-      type: string
-    - default: "false"
-      description: Force rebuild image
-      name: rebuild
       type: string
     - default: "false"
       description: Skip checks against built image
@@ -57,7 +36,7 @@ spec:
       name: hermetic
       type: string
     - default: ""
-      description: Build dependencies to be prefetched by Cachi2
+      description: Build dependencies to be prefetched
       name: prefetch-input
       type: string
     - default: ""
@@ -72,6 +51,14 @@ spec:
       description: Add built image into an OCI image index
       name: build-image-index
       type: string
+    - name: buildah-format
+      default: docker
+      type: string
+      description: The format for the resulting image's mediaType. Valid values are oci or docker.
+    - name: enable-cache-proxy
+      default: "false"
+      description: Enable cache proxy configuration
+      type: string
     - default: []
       description: Array of --build-arg values ("arg=value" strings) for buildah
       name: build-args
@@ -81,7 +68,7 @@ spec:
       name: build-args-file
       type: string
     - default: "false"
-      description: "Whether to enable privileged mode, should be used only with remote VMs"
+      description: Whether to enable privileged mode, should be used only with remote VMs
       name: privileged-nested
       type: string
     - default:
@@ -92,6 +79,22 @@ spec:
       description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array
+    - default: "1"
+      name: depth
+      description: Perform a shallow clone, fetching only the most recent N commits.
+      type: string
+    - default: "false"
+      name: fetchTags
+      description: Fetch all tags for the repo.
+      type: string
+    - default: ""
+      name: refspec
+      description: Refspec to fetch before checking out revision.
+      type: string
+    - default: []
+      description: Additional tags to add to the image
+      name: additional-tags
+      type: array
     - default: "true"
       description: Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.
       name: enable-symlink-check
@@ -100,7 +103,7 @@ spec:
       description: Whether to send slack notification when the pipeline run failed
       name: send-slack-notification
       type: string
-    - default: "" # Need to change for each release, empty for non-release
+    - default: ""
       name: konflux-application-name
       description: The name of the application in Konflux, this is required when send-slack-notification is true
       type: string
@@ -130,14 +133,6 @@ spec:
       name: slack-group-id
       description: |
         The group id of the slack user group, if this is set will mention the group in the slack message; this id can be found by viewing the user group details. e.g. S07XXXXXXXX
-    - name: buildah-format
-      default: docker
-      type: string
-      description: The format for the resulting image's mediaType. Valid values are oci or docker.
-    - name: enable-cache-proxy
-      default: "false"
-      description: Enable cache proxy configuration
-      type: string
   results:
     - description: ""
       name: IMAGE_URL
@@ -174,18 +169,18 @@ spec:
       params:
         - name: url
           value: $(params.git-url)
-        - name: depth
-          value: $(params.depth)
-        - name: fetchTags
-          value: $(params.fetchTags)
-        - name: refspec
-          value: $(params.refspec)
         - name: revision
           value: $(params.revision)
         - name: ociStorage
           value: $(params.output-image).git
         - name: ociArtifactExpiresAfter
           value: $(params.image-expires-after)
+        - name: depth
+          value: $(params.depth)
+        - name: fetchTags
+          value: $(params.fetchTags)
+        - name: refspec
+          value: $(params.refspec)
         - name: enableSymlinkCheck
           value: $(params.enable-symlink-check)
       runAfter:
@@ -268,24 +263,29 @@ spec:
           value:
             - $(params.build-args[*])
             - MCE_VERSION=v$(tasks.fetch-product-metadata.results.z-stream-version)
-        - name: LABELS
-          value:
-            - $(tasks.fetch-product-metadata.results.image-labels[*])
         - name: BUILD_ARGS_FILE
           value: $(params.build-args-file)
         - name: PRIVILEGED_NESTED
           value: $(params.privileged-nested)
+        - name: SOURCE_URL
+          value: $(tasks.clone-repository.results.url)
+        - name: BUILDAH_FORMAT
+          value: $(params.buildah-format)
+        - name: HTTP_PROXY
+          value: $(tasks.init.results.http-proxy)
+        - name: NO_PROXY
+          value: $(tasks.init.results.no-proxy)
         - name: SOURCE_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
         - name: CACHI2_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
         - name: IMAGE_APPEND_PLATFORM
-          value: "true"
-        - name: BUILDAH_FORMAT
-          value: $(params.buildah-format)
+          value: 'true'
+        - name: LABELS
+          value:
+            - $(tasks.fetch-product-metadata.results.image-labels[*])
       runAfter:
         - prefetch-dependencies
-        - fetch-product-metadata
       taskRef:
         params:
           - name: name
@@ -346,7 +346,7 @@ spec:
         - input: $(params.build-source-image)
           operator: in
           values:
-            - "true"
+            - 'true'
     - name: deprecated-base-image-check
       params:
         - name: IMAGE_URL
@@ -368,7 +368,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - matrix:
         params:
           - name: image-platform
@@ -395,8 +395,13 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
-    - name: ecosystem-cert-preflight-checks
+            - 'false'
+    - matrix:
+        params:
+          - name: platform
+            value:
+              - $(params.build-platforms)
+      name: ecosystem-cert-preflight-checks
       params:
         - name: image-url
           value: $(tasks.build-image-index.results.IMAGE_URL)
@@ -415,7 +420,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: sast-snyk-check
       params:
         - name: image-digest
@@ -441,13 +446,13 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
-    - name: clamav-scan
-      matrix:
+            - 'false'
+    - matrix:
         params:
           - name: image-arch
             value:
               - $(params.build-platforms)
+      name: clamav-scan
       params:
         - name: image-digest
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)
@@ -468,13 +473,13 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: sast-coverity-check
       params:
-        - name: image-url
-          value: $(tasks.build-image-index.results.IMAGE_URL)
         - name: image-digest
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
         - name: IMAGE
           value: $(params.output-image)
         - name: DOCKERFILE
@@ -513,7 +518,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
         - input: $(tasks.coverity-availability-check.results.STATUS)
           operator: in
           values:
@@ -534,7 +539,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: sast-shell-check
       params:
         - name: image-digest
@@ -560,7 +565,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: sast-unicode-check
       params:
         - name: image-digest
@@ -586,7 +591,7 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
     - name: apply-tags
       params:
         - name: IMAGE_URL
@@ -650,21 +655,8 @@ spec:
         - input: $(params.skip-checks)
           operator: in
           values:
-            - "false"
+            - 'false'
   finally:
-    - name: show-sbom
-      params:
-        - name: IMAGE_URL
-          value: $(tasks.build-image-index.results.IMAGE_URL)
-      taskRef:
-        params:
-          - name: name
-            value: show-sbom
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:04994df487ee886adbe60a8a5866647fbdfd53cc26f7b2554272ba51bf7af29e
-          - name: kind
-            value: task
-        resolver: bundles
     - name: slack-webhook-notification
       params:
         - name: message

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+ruamel.yaml>=0.18.0

--- a/sync_upstream_pipeline.py
+++ b/sync_upstream_pipeline.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python3
+"""
+Sync local Tekton Pipeline YAML files from konflux-ci/build-definitions.
+
+- Merge .spec.params (add upstream params, keep downstream-only params).
+  For pipeline-level params only, keep `default` from this repo when present.
+- Merge .spec.tasks and .spec.finally: upstream order and non-taskRef fields
+  from upstream; preserve local taskRef; merge per-entry params (if upstream
+  `value` is empty (`[]`, `''`, or absent) and the repo has a non-empty value,
+  keep the repo value; if both upstream and repo `value` are non-empty lists,
+  merge them—upstream order first, then append repo items not already present);
+  merge `when` arrays (upstream order; match clauses by
+  `cel` or `input`+`operator`; fill empty upstream fields from repo; append
+  repo-only clauses); keep
+  allowlisted custom tasks; drop other local-only tasks; inject upstream-only
+  tasks.
+- After merge, drop `spec.params` entries whose `name` never appears as
+  `$(params.<name>)` anywhere in the merged pipeline (including other params).
+- Output uses ruamel.yaml round-trip. Any scalar value containing a newline is
+  emitted as a literal block (|), regardless of key. Indentation matches common
+  yq-style 2-space YAML.
+
+Exit codes: 0 if nothing changed, 200 if at least one pipeline file was updated,
+1 on errors (e.g. missing mapped file).
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import re
+import sys
+import urllib.error
+import urllib.request
+from io import StringIO
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
+from ruamel.yaml.scalarstring import FoldedScalarString, LiteralScalarString
+
+# Upstream map and fetched YAML use the safe loader (no custom tags).
+_safe_yaml = YAML(typ="safe")
+
+# Tekton pipeline param refs: $(params.name), $(params.name[*]), etc.
+_PARAM_REF_RE = re.compile(r"\$\(params\.([^\[\)\.]+)[\[\)\.]")
+
+
+def collect_param_refs_from_obj(obj: Any) -> Set[str]:
+    """Collect $(params.<name>) references anywhere in obj."""
+    names: Set[str] = set()
+    if isinstance(obj, str):
+        names.update(m.group(1) for m in _PARAM_REF_RE.finditer(obj))
+        return names
+    if isinstance(obj, dict):
+        for v in obj.values():
+            names |= collect_param_refs_from_obj(v)
+        return names
+    if isinstance(obj, list):
+        for v in obj:
+            names |= collect_param_refs_from_obj(v)
+        return names
+    return names
+
+
+def prune_unused_spec_params(merged: Dict[str, Any]) -> None:
+    """Drop spec.params entries not referenced as $(params.<name>) in doc."""
+    spec = merged.get("spec")
+    if not spec or "params" not in spec:
+        return
+    params = spec["params"]
+    if not isinstance(params, list):
+        return
+    refs = collect_param_refs_from_obj(merged)
+    kept: List[Any] = []
+    for p in params:
+        if not isinstance(p, dict):
+            kept.append(p)
+            continue
+        name = p.get("name")
+        if name is None:
+            kept.append(p)
+            continue
+        if name in refs:
+            kept.append(p)
+    spec["params"] = kept
+
+
+def make_roundtrip_yaml() -> YAML:
+    """ruamel YAML tuned for yq-like spacing and readable long lines."""
+    y = YAML(typ="rt")
+    y.preserve_quotes = True
+    # yq/Kubernetes style: 2-space indent; sequence indent under mapping key.
+    y.indent(mapping=2, sequence=4, offset=2)
+    y.width = 1024
+    return y
+
+
+def load_map(path: Path) -> tuple[Dict[str, List[str]], List[str]]:
+    raw = _safe_yaml.load(path.read_text())
+    pipelines = raw.get("pipelines")
+    if not pipelines or not isinstance(pipelines, dict):
+        msg = f"{path}: missing 'pipelines' map"
+        raise SystemExit(msg)
+    custom = raw.get("custom-tasks") or []
+    if not isinstance(custom, list):
+        custom = []
+    return pipelines, [str(x) for x in custom]
+
+
+def fetch_upstream(pipeline: str) -> Dict[str, Any]:
+    url = (
+        "https://raw.githubusercontent.com/konflux-ci/build-definitions/"
+        f"refs/heads/main/pipelines/{pipeline}/{pipeline}.yaml"
+    )
+    ua = "konflux-build-catalog-sync"
+    req = urllib.request.Request(url, headers={"User-Agent": ua})
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            data = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        raise SystemExit(f"HTTP {e.code} fetching {url}: {e.reason}") from e
+    except urllib.error.URLError as e:
+        raise SystemExit(f"Failed to fetch {url}: {e}") from e
+    return _safe_yaml.load(data)
+
+
+def commented_to_plain(obj: Any) -> Any:
+    """Convert ruamel round-trip structures to plain Python for merge logic."""
+    if isinstance(obj, CommentedMap):
+        return {k: commented_to_plain(v) for k, v in obj.items()}
+    if isinstance(obj, CommentedSeq):
+        return [commented_to_plain(v) for v in obj]
+    if isinstance(obj, dict):
+        return {k: commented_to_plain(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [commented_to_plain(v) for v in obj]
+    if isinstance(obj, (LiteralScalarString, FoldedScalarString)):
+        return str(obj)
+    return obj
+
+
+def plain_to_roundtrip_tree(plain: Any, yaml_rt: YAML) -> Any:
+    """Round-trip plain data; result is CommentedMap/Seq for dump."""
+    buf = StringIO()
+    yaml_rt.dump(plain, buf)
+    buf.seek(0)
+    return yaml_rt.load(buf)
+
+
+def _needs_literal_block(val: Any) -> bool:
+    """True if we should emit a YAML literal block (|) for this scalar."""
+    if isinstance(val, LiteralScalarString):
+        return False
+    if isinstance(val, FoldedScalarString):
+        return "\n" in str(val)
+    if isinstance(val, str):
+        return "\n" in val
+    return False
+
+
+def ensure_literal_scalar_for_newlines(node: Any) -> None:
+    """
+    Mutate ruamel tree in place: wrap any scalar string that contains a newline
+    in LiteralScalarString so output uses | block style (any key/path).
+    """
+    if isinstance(node, CommentedMap):
+        for k in list(node.keys()):
+            v = node[k]
+            ensure_literal_scalar_for_newlines(v)
+            if _needs_literal_block(v):
+                node[k] = LiteralScalarString(str(v))
+        return
+    if isinstance(node, CommentedSeq):
+        for i in range(len(node)):
+            v = node[i]
+            ensure_literal_scalar_for_newlines(v)
+            if _needs_literal_block(v):
+                node[i] = LiteralScalarString(str(v))
+        return
+    if isinstance(node, dict):
+        for k in list(node.keys()):
+            v = node[k]
+            ensure_literal_scalar_for_newlines(v)
+            if _needs_literal_block(v):
+                node[k] = LiteralScalarString(str(v))
+        return
+    if isinstance(node, list):
+        for i in range(len(node)):
+            v = node[i]
+            ensure_literal_scalar_for_newlines(v)
+            if _needs_literal_block(v):
+                node[i] = LiteralScalarString(str(v))
+        return
+
+
+def _param_value_is_empty(value: Any) -> bool:
+    """True if a task param `value` is unset or explicitly empty ([] or '')."""
+    if value is None:
+        return True
+    if value == []:
+        return True
+    if value == "":
+        return True
+    return False
+
+
+def _merge_param_value_lists(up_val: Any, loc_val: Any) -> Optional[List[Any]]:
+    """
+    If both values are lists, return upstream order plus repo-only items
+    (append each local element if not already in the merged list).
+    """
+    if not isinstance(up_val, list) or not isinstance(loc_val, list):
+        return None
+    out: List[Any] = [copy.deepcopy(x) for x in up_val]
+    for x in loc_val:
+        if x not in out:
+            out.append(copy.deepcopy(x))
+    return out
+
+
+def merge_param_lists(
+    local_params: Optional[List[Dict[str, Any]]],
+    upstream_params: Optional[List[Dict[str, Any]]],
+    *,
+    prefer_local_default: bool = False,
+    prefer_local_value_when_upstream_empty: bool = False,
+) -> List[Dict[str, Any]]:
+    local_params = local_params or []
+    upstream_params = upstream_params or []
+    up_set = {p.get("name") for p in upstream_params if p.get("name")}
+    local_by_name = {p.get("name"): p for p in local_params if p.get("name")}
+    out: List[Dict[str, Any]] = []
+    for up in upstream_params:
+        name = up.get("name")
+        if not name:
+            out.append(copy.deepcopy(up))
+            continue
+        loc = local_by_name.get(name)
+        if loc:
+            merged = copy.deepcopy(loc)
+            for k, v in up.items():
+                merged[k] = copy.deepcopy(v)
+            if prefer_local_default and "default" in loc:
+                merged["default"] = copy.deepcopy(loc["default"])
+            if prefer_local_value_when_upstream_empty:
+                up_val = up.get("value")
+                loc_val = loc.get("value")
+                if _param_value_is_empty(up_val) and not _param_value_is_empty(loc_val):
+                    merged["value"] = copy.deepcopy(loc_val)
+                elif (
+                    isinstance(up_val, list)
+                    and isinstance(loc_val, list)
+                    and not _param_value_is_empty(up_val)
+                    and not _param_value_is_empty(loc_val)
+                ):
+                    merged_list = _merge_param_value_lists(up_val, loc_val)
+                    if merged_list is not None:
+                        merged["value"] = merged_list
+            out.append(merged)
+        else:
+            out.append(copy.deepcopy(up))
+    for loc in local_params:
+        name = loc.get("name")
+        if name and name not in up_set:
+            out.append(copy.deepcopy(loc))
+    return out
+
+
+def _when_clause_key(w: Any) -> Optional[tuple]:
+    """Match key for Tekton WhenExpression / cel entries."""
+    if not isinstance(w, dict):
+        return None
+    if "cel" in w:
+        c = w.get("cel")
+        return ("cel", str(c) if c is not None else "")
+    inp, op = w.get("input"), w.get("operator")
+    if inp is not None and op is not None:
+        return ("io", str(inp), str(op))
+    return None
+
+
+def _merge_when_clause(
+    up_clause: Dict[str, Any], loc_clause: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Start from upstream clause; fill empty upstream fields from repo."""
+    merged = copy.deepcopy(up_clause)
+    for key, lv in loc_clause.items():
+        uv = up_clause.get(key)
+        if _param_value_is_empty(uv) and not _param_value_is_empty(lv):
+            merged[key] = copy.deepcopy(lv)
+    return merged
+
+
+def merge_when_lists(
+    upstream_when: Optional[List[Any]],
+    local_when: Optional[List[Any]],
+) -> List[Any]:
+    """
+    Upstream order; pair each upstream clause with the first unused local
+    clause with the same key (`cel` or `input`+`operator`); merge fields;
+    append any remaining local clauses in local order.
+    """
+    up = upstream_when or []
+    loc = local_when or []
+    if not loc:
+        return copy.deepcopy(up)
+    if not up:
+        return copy.deepcopy(loc)
+
+    used = [False] * len(loc)
+    out: List[Any] = []
+
+    for u in up:
+        k = _when_clause_key(u)
+        merged: Optional[Dict[str, Any]] = None
+        if k is not None and isinstance(u, dict):
+            for i, lw in enumerate(loc):
+                if used[i] or not isinstance(lw, dict):
+                    continue
+                if _when_clause_key(lw) == k:
+                    used[i] = True
+                    merged = _merge_when_clause(u, lw)
+                    break
+        if merged is not None:
+            out.append(merged)
+        else:
+            out.append(copy.deepcopy(u))
+
+    for i, lw in enumerate(loc):
+        if not used[i]:
+            out.append(copy.deepcopy(lw))
+
+    return out
+
+
+def merge_task_entry(
+    upstream_task: Dict[str, Any], local_task: Optional[Dict[str, Any]]
+) -> Dict[str, Any]:
+    if local_task is None:
+        return copy.deepcopy(upstream_task)
+    out = copy.deepcopy(upstream_task)
+    if "taskRef" in local_task:
+        out["taskRef"] = copy.deepcopy(local_task["taskRef"])
+    out["params"] = merge_param_lists(
+        local_task.get("params"),
+        upstream_task.get("params"),
+        prefer_local_value_when_upstream_empty=True,
+    )
+    out["when"] = merge_when_lists(
+        upstream_task.get("when"),
+        local_task.get("when") if local_task else None,
+    )
+    for key in list(out.keys()):
+        if out[key] is None or out[key] == []:
+            del out[key]
+    return out
+
+
+def _names_in_order(task_list: Optional[List[Dict[str, Any]]]) -> List[str]:
+    if not task_list:
+        return []
+    return [t["name"] for t in task_list if t.get("name")]
+
+
+def sync_task_list(
+    local_tasks: Optional[List[Dict[str, Any]]],
+    upstream_tasks: Optional[List[Dict[str, Any]]],
+    custom_allowed: Set[str],
+) -> List[Dict[str, Any]]:
+    """
+    Build merged task list: strict upstream order for upstream-defined names,
+    merged fields (taskRef from local); insert allowlisted custom-only tasks at
+    positions implied by local order.
+    """
+    local_tasks = local_tasks or []
+    upstream_tasks = upstream_tasks or []
+    up_order = _names_in_order(upstream_tasks)
+    up_by = {t["name"]: t for t in upstream_tasks if t.get("name")}
+    loc_by = {t["name"]: t for t in local_tasks if t.get("name")}
+
+    result: List[Dict[str, Any]] = []
+    for name in up_order:
+        result.append(merge_task_entry(up_by[name], loc_by.get(name)))
+
+    custom_only: List[tuple[str, Dict[str, Any]]] = []
+    for t in local_tasks:
+        n = t.get("name")
+        if not n or n in up_by:
+            continue
+        if n in custom_allowed:
+            custom_only.append((n, copy.deepcopy(t)))
+
+    for n, task_copy in custom_only:
+        idx = next(
+            (i for i, lt in enumerate(local_tasks) if lt.get("name") == n),
+            -1,
+        )
+        if idx < 0:
+            continue
+        pred: Optional[str] = None
+        for j in range(idx - 1, -1, -1):
+            pn = local_tasks[j].get("name")
+            if not pn:
+                continue
+            if pn in up_by or pn in {c[0] for c in custom_only}:
+                pred = pn
+                break
+        if pred is None:
+            insert_at = 0
+        else:
+            pos = next(
+                (i for i, r in enumerate(result) if r.get("name") == pred),
+                None,
+            )
+            if pos is None:
+                insert_at = len(result)
+            else:
+                insert_at = pos + 1
+        result.insert(insert_at, task_copy)
+
+    return result
+
+
+def merge_pipeline(
+    local_doc: Dict[str, Any],
+    upstream_doc: Dict[str, Any],
+    custom_allowed: Set[str],
+) -> Dict[str, Any]:
+    out = copy.deepcopy(local_doc)
+    local_spec = local_doc.get("spec") or {}
+    upstream_spec = upstream_doc.get("spec") or {}
+    if "spec" not in out:
+        out["spec"] = {}
+    spec = out["spec"]
+    spec["params"] = merge_param_lists(
+        local_spec.get("params"),
+        upstream_spec.get("params"),
+        prefer_local_default=True,
+    )
+    spec["tasks"] = sync_task_list(
+        local_spec.get("tasks"), upstream_spec.get("tasks"), custom_allowed
+    )
+    spec["finally"] = sync_task_list(
+        local_spec.get("finally"),
+        upstream_spec.get("finally"),
+        custom_allowed,
+    )
+    prune_unused_spec_params(out)
+    return out
+
+
+def dump_merged_pipeline(merged_plain: Dict[str, Any], yaml_rt: YAML) -> str:
+    """Merged plain dict to round-trip YAML; newline scalars use | blocks."""
+    merged_rt = plain_to_roundtrip_tree(merged_plain, yaml_rt)
+    ensure_literal_scalar_for_newlines(merged_rt)
+    buf = StringIO()
+    yaml_rt.dump(merged_rt, buf)
+    return buf.getvalue()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Sync pipelines/ YAML from konflux-ci/build-definitions "
+            "per upstream-map.yaml"
+        )
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print actions only; do not write files",
+    )
+    parser.add_argument(
+        "pipeline_file",
+        nargs="?",
+        default=None,
+        help="(Optional) Pipeline file to sync"
+    )
+    args = parser.parse_args()
+
+    yaml_rt = make_roundtrip_yaml()
+    repo_root = Path(__file__).resolve().parent
+    map_path = repo_root / "upstream-map.yaml"
+    pipelines_map, custom_tasks = load_map(map_path)
+    custom_set = set(custom_tasks)
+    pipelines_dir = repo_root / "pipelines"
+    if not pipelines_dir.is_dir():
+        raise SystemExit(f"Not a directory: {pipelines_dir}")
+
+    exit_code = 0
+    any_updates = False
+    for upstream_name, rel_files in pipelines_map.items():
+        if not isinstance(rel_files, list):
+            continue
+        msg = f"Fetching upstream pipeline {upstream_name!r} ..."
+        print(msg, file=sys.stderr)
+        upstream_doc = fetch_upstream(upstream_name)
+        for rel in rel_files:
+            path = pipelines_dir / rel
+            if not path.is_file():
+                print(f"  skip missing file: {path}", file=sys.stderr)
+                exit_code = 1
+                continue
+            if args.pipeline_file and path != repo_root / args.pipeline_file:
+                continue
+            original_text = path.read_text(encoding="utf-8")
+            local_rt = yaml_rt.load(original_text)
+            local_plain = commented_to_plain(local_rt)
+            merged_plain = merge_pipeline(
+                local_plain, upstream_doc, custom_set)
+            text = dump_merged_pipeline(merged_plain, yaml_rt)
+            changed = text != original_text
+            if changed:
+                any_updates = True
+            if args.dry_run:
+                if changed:
+                    print(f"Would write {path}", file=sys.stderr)
+                continue
+            if changed:
+                path.write_text(text, encoding="utf-8")
+                print(f"Updated {path}", file=sys.stderr)
+
+    if exit_code:
+        sys.exit(exit_code)
+    if any_updates:
+        sys.exit(200)
+
+
+if __name__ == "__main__":
+    main()

--- a/upstream-map.yaml
+++ b/upstream-map.yaml
@@ -1,0 +1,13 @@
+pipelines:
+  docker-build-multi-platform-oci-ta:
+    - common.yaml
+    - common-base.yaml
+    - common-stage.yaml
+  docker-build-oci-ta:
+    - common-oci-ta.yaml
+  fbc-builder:
+    - common-fbc.yaml
+    - common-fbc-nofips.yaml
+custom-tasks:
+  - fetch-product-metadata
+  - slack-webhook-notification


### PR DESCRIPTION
This has been in my backlog for a bit. We've done well to keep task image SHA references up-to-date, but not the configuration/params around the task.

The `show-sbom` task was actually removed upstream, and the script here indeed removed it when the new script was run.

One of the limitations of this script is that it pulls the `taskRef` directly when a new task is added, so it reference the task directly rather than using the image pull, which would break. It probably wouldn't be too hard to add that logic in a followup to this PR.

Assisted-by: Cursor IDE