### PR TITLE
fix: pin `kubectl` version for `kubeopencode`

### DIFF
--- a/.github/workflows/update-tekton-task-bundles.yaml
+++ b/.github/workflows/update-tekton-task-bundles.yaml
@@ -279,7 +279,7 @@ jobs:
           KUBEOPENCODE_TOKEN: ${{ secrets.KUBEOPENCODE_TOKEN }}
           KUBEOPENCODE_CA: ${{ secrets.KUBEOPENCODE_CA }}
         run: |
-          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable-1.35.txt)/bin/linux/amd64/kubectl"
           chmod +x kubectl
           sudo mv kubectl /usr/local/bin/
 


### PR DESCRIPTION
Trying to avoid this error, which can appear when there's skew between the server k8s version and `kubectl`, the latter of which had a new version 2 days ago:

```
error: error validating "STDIN":
error validating data:
failed to download openapi:
the server has asked for the client to provide credentials; if you choose to ignore these errors, turn validation off with --validate=false
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. This update addresses internal workflow infrastructure configuration and does not impact end-user functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->