### PR TITLE
chore: reconfigure pipelines for new application

### DIFF
--- a/.tekton/common-pipeline-base-pull-request.yaml
+++ b/.tekton/common-pipeline-base-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-build-catalog
-    appstudio.openshift.io/component: common-pipeline
+    appstudio.openshift.io/component: common-pipeline-base
     pipelines.appstudio.openshift.io/type: build
   name: common-pipeline-base-on-pull-request
   namespace: crt-redhat-acm-tenant
@@ -25,7 +25,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline-base:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
     - name: dockerfile
@@ -43,7 +43,7 @@ spec:
       - name: pathInRepo
         value: pipelines/common-base.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-common-pipeline
+    serviceAccountName: build-pipeline-common-pipeline-base
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/common-pipeline-fbc-pull-request.yaml
+++ b/.tekton/common-pipeline-fbc-pull-request.yaml
@@ -13,8 +13,8 @@ metadata:
       == "main" && ("pipelines/common-fbc.yaml".pathChanged() || ".tekton/common-pipeline-fbc-pull-request.yaml".pathChanged())
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: konflux-build-catalog
-    appstudio.openshift.io/component: common-pipeline
+    appstudio.openshift.io/application: konflux-build-catalog-fbc
+    appstudio.openshift.io/component: common-pipeline-fbc
     pipelines.appstudio.openshift.io/type: build
   name: common-pipeline-fbc-pull-request
   namespace: crt-redhat-acm-tenant
@@ -25,7 +25,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline-fbc:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
     - name: dockerfile
@@ -53,7 +53,7 @@ spec:
       - name: pathInRepo
         value: pipelines/common-fbc.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-common-pipeline
+    serviceAccountName: build-pipeline-common-pipeline-fbc
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/common-pipeline-oci-ta-pull-request.yaml
+++ b/.tekton/common-pipeline-oci-ta-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-build-catalog
-    appstudio.openshift.io/component: common-pipeline
+    appstudio.openshift.io/component: common-pipeline-oci-ta
     pipelines.appstudio.openshift.io/type: build
   name: common-pipeline-oci-ta-pull-request
   namespace: crt-redhat-acm-tenant
@@ -25,7 +25,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline-oci-ta:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
     - name: dockerfile
@@ -43,7 +43,7 @@ spec:
       - name: pathInRepo
         value: pipelines/common-oci-ta.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-common-pipeline
+    serviceAccountName: build-pipeline-common-pipeline-oci-ta
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/common-pipeline-stage-pull-request.yaml
+++ b/.tekton/common-pipeline-stage-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-build-catalog
-    appstudio.openshift.io/component: common-pipeline
+    appstudio.openshift.io/component: common-pipeline-stage
     pipelines.appstudio.openshift.io/type: build
   name: common-pipeline-stage-on-pull-request
   namespace: crt-redhat-acm-tenant
@@ -25,7 +25,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline-stage:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
     - name: dockerfile
@@ -43,7 +43,7 @@ spec:
       - name: pathInRepo
         value: pipelines/common-stage.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-common-pipeline
+    serviceAccountName: build-pipeline-common-pipeline-stage
   workspaces:
     - name: git-auth
       secret:

--- a/tasks/fetch-product-metadata/fetch-product-metadata.yaml
+++ b/tasks/fetch-product-metadata/fetch-product-metadata.yaml
@@ -51,7 +51,7 @@ spec:
         echo "* Extracting image repository"
         output_image_repo=$(echo "${OUTPUT_IMAGE}" | grep -oE '[a-z0-9-]+-(acm|mce)-[0-9]+' | tail -n 1 )
         echo "  Image repository: '${output_image_repo}'"
-        if [[ ${OUTPUT_IMAGE} == "quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline:"* ]]; then
+        if [[ ${OUTPUT_IMAGE} == "quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline"* ]]; then
           echo "* Output image is a common pipeline image, skipping"
           echo -n "" >"$(step.results.component.path)"
           echo -n "" >"$(step.results.product.path)"

--- a/tasks/fetch-product-metadata/parse-output-image.sh
+++ b/tasks/fetch-product-metadata/parse-output-image.sh
@@ -11,7 +11,7 @@ fi
 echo "* Extracting image repository"
 output_image_repo=$(echo "${OUTPUT_IMAGE}" | grep -oE '[a-z0-9-]+-(acm|mce)-[0-9]+' | tail -n 1 )
 echo "  Image repository: '${output_image_repo}'"
-if [[ ${OUTPUT_IMAGE} == "quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline:"* ]]; then
+if [[ ${OUTPUT_IMAGE} == "quay.io/redhat-user-workloads/crt-redhat-acm-tenant/common-pipeline"* ]]; then
   echo "* Output image is a common pipeline image, skipping"
   echo -n "" >"$(step.results.component.path)"
   echo -n "" >"$(step.results.product.path)"


### PR DESCRIPTION
By separating the components and establishing a new FBC application, each component has an isolated build, FBC is correctly attached to an FBC Conforma policy, and Conforma won't halt due to concurrent instances.

Blocked by the Konflux application deployment:

- https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/17630

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pipeline runs updated to use variant-specific component labels, output image tags, and service accounts for base, fbc, oci-ta, and stage variants — improving artifact tagging, isolation, and consistent pipeline behavior across variants.
* **Bug Fixes**
  * Improved image-detection logic so more common-pipeline image variants are correctly recognized during metadata fetch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->