### PR TITLE
fix: improve metadata error messaging

### DIFF
--- a/tasks/fetch-product-metadata/fetch-product-metadata.yaml
+++ b/tasks/fetch-product-metadata/fetch-product-metadata.yaml
@@ -143,12 +143,13 @@ spec:
         fi
 
         repo="${PRODUCT}-operator-bundle"
+        repo_url="https://github.com/stolostron/${repo}"
 
         echo "* Cloning '${repo}' repository at branch '${BRANCH}'"
         git clone \
           --depth 1 \
           --branch "${BRANCH}" \
-          "https://github.com/stolostron/${repo}"
+          "${repo_url}"
 
         cd "${repo}" || {
           echo "error: failed to change directory to '${repo}'" >&2
@@ -173,16 +174,24 @@ spec:
 
         ga_image_namespace=$(jq -r '.["product-images"].["image-namespace"] // ""' "${config_path}")
         ga_image_name=$(
-          jq -er '.["product-images"].["image-list"][]
+          jq -r '.["product-images"].["image-list"][]
             | select(.["konflux-component-name"] == "'"${COMPONENT}"'")
             | .["publish-name"] // ""' "${config_path}"
         )
-        rhel_version=$(echo "${ga_image_name}" | sed -E 's/.*-rh(el[0-9]+)(-.*)?/\1/')
+        rhel_version=""
+        if [[ ${ga_image_name} =~ -rh(el[0-9]+)(-.*)?$ ]]; then
+          rhel_version="${BASH_REMATCH[1]}"
+        fi
         echo "  GA image namespace: '${ga_image_namespace}'"
         echo "  GA image name: '${ga_image_name}'"
         echo "  RHEL version: '${rhel_version}'"
         if [[ -z ${ga_image_namespace} ]] || [[ -z ${ga_image_name} ]]; then
           echo "error: failed to parse GA image namespace or name from ${config_path}" >&2
+          echo "  Verify the ${COMPONENT} Konflux component is defined in ${repo_url}/blob/${BRANCH}/${config_path}" >&2
+          exit 1
+        fi
+        if [[ -z ${rhel_version} ]]; then
+          echo "error: failed to parse RHEL version from GA image name '${ga_image_name}'. Expected '<name>-rhel<version>[-<suffix>]'." >&2
           exit 1
         fi
 

--- a/tasks/fetch-product-metadata/parse-product-metadata.sh
+++ b/tasks/fetch-product-metadata/parse-product-metadata.sh
@@ -14,12 +14,13 @@ if [[ -z ${PRODUCT} ]] || [[ -z ${BRANCH} ]]; then
 fi
 
 repo="${PRODUCT}-operator-bundle"
+repo_url="https://github.com/stolostron/${repo}"
 
 echo "* Cloning '${repo}' repository at branch '${BRANCH}'"
 git clone \
   --depth 1 \
   --branch "${BRANCH}" \
-  "https://github.com/stolostron/${repo}"
+  "${repo_url}"
 
 cd "${repo}" || {
   echo "error: failed to change directory to '${repo}'" >&2
@@ -44,16 +45,24 @@ fi
 
 ga_image_namespace=$(jq -r '.["product-images"].["image-namespace"] // ""' "${config_path}")
 ga_image_name=$(
-  jq -er '.["product-images"].["image-list"][]
+  jq -r '.["product-images"].["image-list"][]
     | select(.["konflux-component-name"] == "'"${COMPONENT}"'")
     | .["publish-name"] // ""' "${config_path}"
 )
-rhel_version=$(echo "${ga_image_name}" | sed -E 's/.*-rh(el[0-9]+)(-.*)?/\1/')
+rhel_version=""
+if [[ ${ga_image_name} =~ -rh(el[0-9]+)(-.*)?$ ]]; then
+  rhel_version="${BASH_REMATCH[1]}"
+fi
 echo "  GA image namespace: '${ga_image_namespace}'"
 echo "  GA image name: '${ga_image_name}'"
 echo "  RHEL version: '${rhel_version}'"
 if [[ -z ${ga_image_namespace} ]] || [[ -z ${ga_image_name} ]]; then
   echo "error: failed to parse GA image namespace or name from ${config_path}" >&2
+  echo "  Verify the ${COMPONENT} Konflux component is defined in ${repo_url}/blob/${BRANCH}/${config_path}" >&2
+  exit 1
+fi
+if [[ -z ${rhel_version} ]]; then
+  echo "error: failed to parse RHEL version from GA image name '${ga_image_name}'. Expected '<name>-rhel<version>[-<suffix>]'." >&2
   exit 1
 fi
 


### PR DESCRIPTION
The `jq -e` command is causing the script to short-circuit before an error message is printed. Also adds a URL to the message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when product metadata parsing fails, adding a clearer verification hint that points to the relevant repo/branch configuration path.
  * Validation now ensures image namespace/name and RHEL version are present before proceeding.

* **Refactor**
  * Repository cloning now constructs bundle repository URLs dynamically for robustness.
  * Image metadata extraction and RHEL version detection have been tightened and streamlined to catch configuration issues earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->