### PR TITLE
feat: add Task base image update workflow

### DIFF
--- a/.github/workflows/update-tekton-task-bundles.yaml
+++ b/.github/workflows/update-tekton-task-bundles.yaml
@@ -23,6 +23,51 @@ jobs:
           echo "* Found pipeline files: ${pipeline_files}"
           echo "pipeline_files=${pipeline_files}" >>"${GITHUB_OUTPUT}"
 
+  update-task-base-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y skopeo jq
+          sudo wget -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Update task base image
+        run: |
+          ./build/update-task-base-image.sh
+
+      - name: Check if pipeline file changed
+        id: check_diff
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          if git diff --quiet tasks/; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request if needed
+        if: steps.check_diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          commit-message: "chore: update Tekton Task base images"
+          title: "chore: update Tekton Task base images"
+          body: |-
+            Automated PR to update Tekton Task base images.
+          branch: tekton-task-base-image-update
+          base: main
+          add-paths: tasks/
+          signoff: true
+          labels: |
+            automated-update
+
   update-tekton-task-bundles:
     needs: generate-matrix
     runs-on: ubuntu-latest

--- a/build/update-task-base-image.sh
+++ b/build/update-task-base-image.sh
@@ -1,0 +1,75 @@
+#! /bin/bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)
+task_dir=$(realpath "${script_dir}/../tasks")
+
+# Detect OS and set sed in-place flag accordingly
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  SED_INPLACE=(-i '')
+else
+  SED_INPLACE=(-i)
+fi
+
+for dir in "${task_dir}"/*; do
+  if [[ ! -d ${dir} ]]; then
+    continue
+  fi
+
+  task_name=$(basename "${dir}")
+  echo "* Updating task ${task_name}"
+
+  if ! [[ -f "${dir}/${task_name}.yaml.template" ]]; then
+    echo "error: task template ${dir}/${task_name}.yaml.template not found" >&2
+    exit 1
+  fi
+
+  base_image=$(yq -e '.spec.stepTemplate.image' "${task_dir}/${task_name}/${task_name}.yaml.template")
+  echo "  - Base image: ${base_image}"
+  image_and_tag=${base_image%@sha256:*}
+  image_tag=${image_and_tag##*:}
+  image_repo=${image_and_tag%:*}
+
+  # Validate image format contains both tag and digest
+  if [[ ! ${base_image} =~ @sha256: ]]; then
+    echo "ERROR: Base image does not contain digest pinning" >&2
+    exit 1
+  fi
+
+  if [[ -z ${image_and_tag} ]]; then
+    echo "ERROR: failed to parse image and tag from ${base_image}" >&2
+    exit 1
+  fi
+
+  if [[ -z ${image_repo} || -z ${image_tag} ]]; then
+    echo "ERROR: failed to parse image repo or tag from ${base_image}" >&2
+    exit 1
+  fi
+
+  latest_version_tag=$(skopeo list-tags "docker://${image_repo}" | yq '.Tags[]' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort --version-sort | tail -n 1 || true)
+
+  if [[ -z ${latest_version_tag} ]]; then
+    echo "ERROR: failed to fetch latest version tag for ${image_repo}" >&2
+    exit 1
+  fi
+
+  if [[ ${image_tag} == "${latest_version_tag}" ]]; then
+    echo "  - Tag ${image_tag} is up-to-date"
+    continue
+  else
+    echo "  - Updating tag ${image_tag} to ${latest_version_tag}"
+  fi
+
+  latest_version_digest=$(skopeo inspect --override-os linux --override-arch amd64 "docker://${image_repo}:${latest_version_tag}" | yq '.Digest')
+  if [[ -z ${latest_version_digest} || ! ${latest_version_digest} =~ ^sha256: ]]; then
+    echo "ERROR: failed to fetch digest for ${image_repo}:${latest_version_tag}" >&2
+    exit 1
+  fi
+
+  new_image="${image_repo}:${latest_version_tag}@${latest_version_digest}"
+  echo "  - New image: ${new_image}"
+  sed "${SED_INPLACE[@]}" -e "s!${base_image}!${new_image}!g" "${task_dir}/${task_name}/${task_name}.yaml.template"
+done
+
+"${script_dir}/generate-tasks.sh"


### PR DESCRIPTION
I realized the base image for the Task was stale but there wasn't a flow here to keep it up-to-date. This should update the base image and then the pipeline task references would be updated in the subsequent week.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow that scans task templates for outdated base images, resolves and pins them to exact digests, regenerates tasks, and opens an automated pull request when updates are detected.
  * Includes a strict update utility with input validation and failsafe checks; workflow installs required utilities before running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->