### PR TITLE
fix: use OWNERS file for issue assignee

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,26 +2,24 @@
 # This file defines who needs to review changes to specific files or directories
 
 # Default owners for the entire repository
-* @zhujian7 @xuezhaojun @jnpacker @dhaiducek
+* @jnpacker @dhaiducek @gparvin @dislbenn
 
 # Specific ownership for .tekton pipeline files
 # Each file can be assigned to different maintainers for specialized review
 
-.tekton/common-pipeline-pull-request.yaml @clyang82
-.tekton/common-pipeline-push.yaml @clyang82
-.tekton/common-pipeline-mce-* @zhujian7 @xuezhaojun
-.tekton/common-pipeline-oci-ta-pull-request.yaml @clyang82
-.tekton/common-pipeline-fbc-pull-request.yaml @clyang82
+.tekton/common-pipeline-pull-request.yaml @dhaiducek @gparvin @dislbenn
+.tekton/common-pipeline-push.yaml @dhaiducek @gparvin @dislbenn
+.tekton/common-pipeline-oci-ta-pull-request.yaml @dhaiducek @gparvin @dislbenn
+.tekton/common-pipeline-fbc-pull-request.yaml @dhaiducek @gparvin @dislbenn
 
 # Pipeline source files
-pipelines/common.yaml @clyang82
-pipelines/common_mce_* @zhujian7 @xuezhaojun
-pipelines/common-oci-ta.yaml @clyang82
-pipelines/common-fbc.yaml @clyang82
+pipelines/common.yaml @dhaiducek @gparvin @dislbenn
+pipelines/common-oci-ta.yaml @dhaiducek @gparvin @dislbenn
+pipelines/common-fbc.yaml @dhaiducek @gparvin @dislbenn
 
 # Automation scripts
-update-tekton-task-bundles.sh @xuezhaojun
-.github/workflows/ @xuezhaojun
+update-tekton-task-bundles.sh @dhaiducek @gparvin @dislbenn
+.github/workflows/ @dhaiducek @gparvin @dislbenn
 
 # Mintmaker
-mintmaker/ @dhaiducek
+mintmaker/ @dhaiducek @gparvin @dislbenn

--- a/.github/workflows/update-tekton-task-bundles.yaml
+++ b/.github/workflows/update-tekton-task-bundles.yaml
@@ -121,6 +121,8 @@ jobs:
       - name: Check if migration is required
         id: check_migration
         run: |
+          echo "assignees=$(yq '.approvers | join(",")' OWNERS)" >> $GITHUB_OUTPUT
+
           if jq -e 'length > 0' migration_data.json; then
             echo "migration_required=true" >> $GITHUB_OUTPUT
 
@@ -208,7 +210,7 @@ jobs:
               format('New configuration detected for `{0}` requiring manual review', matrix.pipeline_file)
             }}
           labels: "migration, ${{ steps.extract_filename.outputs.filename_label }}"
-          assignees: ${{ github.actor }}
+          assignees: ${{ steps.check_migration.outputs.assignees }}
 
       - name: Send Slack notification for migration
         if: steps.check_migration.outputs.migration_required == 'true' &&

--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,11 @@
 approvers:
-- clyang82
 - dhaiducek
 - dislbenn
-- elgnay
 - gparvin
 - jnpacker
 
 reviewers:
-- clyang82
 - dhaiducek
 - dislbenn
-- elgnay
 - gparvin
 - jnpacker


### PR DESCRIPTION
Prevents this error:
```
Error: Error encountered: HttpError: Validation Failed: {"message":"assignees xuezhaojun cannot be assigned to this issue","value":["xuezhaojun"],"resource":"Issue","field":"assignees","code":"invalid"} - https://docs.github.com/rest/issues/issues#create-an-issue.
```
ref: https://github.com/stolostron/konflux-build-catalog/actions/runs/27888423156/job/82527512625#step:11:129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the “Update Tekton Task Bundles” automation so migration issues are now assigned to the computed approver list from the repository ownership settings.
  * Refreshed repository ownership configuration so relevant owners/maintainers are updated across the default scope and Tekton/pipeline-related paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->