### PR TITLE
chore: update task bundle references to new versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,18 +186,23 @@ Follow this PR to understand how to update your repository: https://github.com/s
 ## Common Commands
 
 ### Update Tekton Task Bundles
+
 ```bash
 # Update all bundle references to latest versions
-bash update-tekton-task-bundles.sh pipelines/common.yaml
+./update-tekton-task-bundles.sh pipelines/common.yaml
 
 # Update multiple pipeline files at once
-bash update-tekton-task-bundles.sh pipelines/common.yaml pipelines/common-fbc.yaml
+./update-tekton-task-bundles.sh pipelines/common.yaml pipelines/common-fbc.yaml
 
 # Update all pipeline files
-bash update-tekton-task-bundles.sh pipelines/*.yaml
+./update-tekton-task-bundles.sh pipelines/*.yaml
+
+# Update all pipeline files with version migrations
+MIGRATE=true ./update-tekton-task-bundles.sh pipelines/*.yaml
 ```
 
 ### Validate Pipeline YAML
+
 ```bash
 # Validate YAML syntax for single file
 yq eval pipelines/common.yaml > /dev/null

--- a/pipelines/common-base.yaml
+++ b/pipelines/common-base.yaml
@@ -223,7 +223,7 @@ spec:
           - name: name
             value: prefetch-dependencies-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:3dc78afbf3a441e0280067433cb28ea3d2d0088ec214c73bf063f145b4f273ef
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:7e84b01526b6a50b920c0f456c8d95d6c5c2f7b81109ea772e1dcf7aba14bfa5
           - name: kind
             value: task
         resolver: bundles
@@ -281,7 +281,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.9@sha256:77007259cc87f32d63d2c201226aadaab98313cfd4e02b46abc243c4d2cc27bd
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.10@sha256:1eaac50bb7e77feccfe3f0a521714de6a153387d3847bd94542e2a974bb05121
           - name: kind
             value: task
         resolver: bundles
@@ -373,7 +373,7 @@ spec:
           - name: name
             value: clair-scan
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3.2@sha256:8fad4c2e2f470f82ee43d6b2ac72327b4d9c6e9cb514a678911c1c9359c29894
+            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3.2@sha256:312fb4d135e351bde38bcb14a7897b238d0aac19703b4e507c105f12b57836f1
           - name: kind
             value: task
         resolver: bundles
@@ -398,7 +398,7 @@ spec:
           - name: name
             value: ecosystem-cert-preflight-checks
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:88f4fd6d7812a3c46f120f3035974f5fb8cb06b5e3e927badf6e8370f1516a88
+            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:3c4f60ebda2225eff6a6bc387d9bbd443f1264d756bf385f97cc684992e904a0
           - name: kind
             value: task
         resolver: bundles
@@ -426,7 +426,7 @@ spec:
           - name: name
             value: sast-snyk-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:0ebf28a0abd5a167438d4628938a74ade6f00a44a4b7ed1cfa9cfc57a5b24748
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:2db846fa5d8e593b4def045693d79ebd01802ec6edeea0f6003a23167a8a078e
           - name: kind
             value: task
         resolver: bundles
@@ -481,7 +481,7 @@ spec:
           - name: name
             value: sast-shell-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:3cbb3535af6e7d4396858179a6427caaffb2e68775594795692fc01f28ae313f
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:fc685d6f7dfb7c9ab2f2db38bbe2c8d383407847350ccd8b96352322c487b13c
           - name: kind
             value: task
         resolver: bundles
@@ -509,7 +509,7 @@ spec:
           - name: name
             value: sast-unicode-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:223812001607b07f0e07d56bef7b7d619144e660c0c57f21ddd44ce0c8c4785b
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:5807ffe3a0cca5cf970076bbc7a404642cc6e3eebe64e9e5e6a4f20da740bf73
           - name: kind
             value: task
         resolver: bundles
@@ -573,7 +573,7 @@ spec:
           - name: name
             value: rpms-signature-scan
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2.1@sha256:237c54b069d16c3785d1302f19be309aa6c0ae2313d446e30cb74671e07ca676
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2.1@sha256:e42148ce79713de1536d15161c0a7b8bfb138bc046ad663098d9b56d5810be47
           - name: kind
             value: task
         resolver: bundles
@@ -604,7 +604,7 @@ spec:
       taskRef:
         params:
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:14766aebbf6f4739e1b7dde0406dcba2d1e300170d3b084f23df9fb074d87dc3
+            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:d34a3789505f829493636a265eb04790695dba84bbb2bb716a7551a6911f2816
           - name: name
             value: slack-webhook-notification
           - name: kind

--- a/pipelines/common-fbc.yaml
+++ b/pipelines/common-fbc.yaml
@@ -30,7 +30,7 @@ spec:
       taskRef:
         params:
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:14766aebbf6f4739e1b7dde0406dcba2d1e300170d3b084f23df9fb074d87dc3
+            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:d34a3789505f829493636a265eb04790695dba84bbb2bb716a7551a6911f2816
           - name: name
             value: slack-webhook-notification
           - name: kind
@@ -254,7 +254,7 @@ spec:
           - name: name
             value: prefetch-dependencies-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:3dc78afbf3a441e0280067433cb28ea3d2d0088ec214c73bf063f145b4f273ef
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:7e84b01526b6a50b920c0f456c8d95d6c5c2f7b81109ea772e1dcf7aba14bfa5
           - name: kind
             value: task
         resolver: bundles
@@ -308,7 +308,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.9@sha256:77007259cc87f32d63d2c201226aadaab98313cfd4e02b46abc243c4d2cc27bd
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.10@sha256:1eaac50bb7e77feccfe3f0a521714de6a153387d3847bd94542e2a974bb05121
           - name: kind
             value: task
         resolver: bundles
@@ -436,7 +436,7 @@ spec:
           - name: name
             value: fbc-fips-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:23c6e304a68d4b103007916aa5af7aee7898c1737d6879a64dc984138cbd22b6
+            value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:e957d0399fb5579163f00967aea2c137cf25d0679592e4a480e8d850db18d4f0
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common-oci-ta.yaml
+++ b/pipelines/common-oci-ta.yaml
@@ -30,7 +30,7 @@ spec:
       taskRef:
         params:
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:14766aebbf6f4739e1b7dde0406dcba2d1e300170d3b084f23df9fb074d87dc3
+            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:d34a3789505f829493636a265eb04790695dba84bbb2bb716a7551a6911f2816
           - name: name
             value: slack-webhook-notification
           - name: kind
@@ -223,7 +223,7 @@ spec:
           - name: name
             value: prefetch-dependencies-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:3dc78afbf3a441e0280067433cb28ea3d2d0088ec214c73bf063f145b4f273ef
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:7e84b01526b6a50b920c0f456c8d95d6c5c2f7b81109ea772e1dcf7aba14bfa5
           - name: kind
             value: task
         resolver: bundles
@@ -274,7 +274,7 @@ spec:
           - name: name
             value: buildah-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.9@sha256:75ecb662f343f6f34e553c5b37734d28d9b53ce218c2321a19b96c39bf769357
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.10@sha256:1d633027ed426996720890ec9a74576ae264d711a177bf18f39a5a9e8023435c
           - name: kind
             value: task
         resolver: bundles
@@ -361,7 +361,7 @@ spec:
           - name: name
             value: clair-scan
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3.2@sha256:8fad4c2e2f470f82ee43d6b2ac72327b4d9c6e9cb514a678911c1c9359c29894
+            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3.2@sha256:312fb4d135e351bde38bcb14a7897b238d0aac19703b4e507c105f12b57836f1
           - name: kind
             value: task
         resolver: bundles
@@ -381,7 +381,7 @@ spec:
           - name: name
             value: ecosystem-cert-preflight-checks
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:88f4fd6d7812a3c46f120f3035974f5fb8cb06b5e3e927badf6e8370f1516a88
+            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:3c4f60ebda2225eff6a6bc387d9bbd443f1264d756bf385f97cc684992e904a0
           - name: kind
             value: task
         resolver: bundles
@@ -409,7 +409,7 @@ spec:
           - name: name
             value: sast-snyk-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:0ebf28a0abd5a167438d4628938a74ade6f00a44a4b7ed1cfa9cfc57a5b24748
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:2db846fa5d8e593b4def045693d79ebd01802ec6edeea0f6003a23167a8a078e
           - name: kind
             value: task
         resolver: bundles
@@ -459,7 +459,7 @@ spec:
           - name: name
             value: sast-shell-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:3cbb3535af6e7d4396858179a6427caaffb2e68775594795692fc01f28ae313f
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:fc685d6f7dfb7c9ab2f2db38bbe2c8d383407847350ccd8b96352322c487b13c
           - name: kind
             value: task
         resolver: bundles
@@ -487,7 +487,7 @@ spec:
           - name: name
             value: sast-unicode-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:223812001607b07f0e07d56bef7b7d619144e660c0c57f21ddd44ce0c8c4785b
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:5807ffe3a0cca5cf970076bbc7a404642cc6e3eebe64e9e5e6a4f20da740bf73
           - name: kind
             value: task
         resolver: bundles
@@ -551,7 +551,7 @@ spec:
           - name: name
             value: rpms-signature-scan
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2.1@sha256:237c54b069d16c3785d1302f19be309aa6c0ae2313d446e30cb74671e07ca676
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2.1@sha256:e42148ce79713de1536d15161c0a7b8bfb138bc046ad663098d9b56d5810be47
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common-stage.yaml
+++ b/pipelines/common-stage.yaml
@@ -213,7 +213,7 @@ spec:
           - name: name
             value: prefetch-dependencies-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:3dc78afbf3a441e0280067433cb28ea3d2d0088ec214c73bf063f145b4f273ef
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:7e84b01526b6a50b920c0f456c8d95d6c5c2f7b81109ea772e1dcf7aba14bfa5
           - name: kind
             value: task
         resolver: bundles
@@ -275,7 +275,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.9@sha256:77007259cc87f32d63d2c201226aadaab98313cfd4e02b46abc243c4d2cc27bd
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.10@sha256:1eaac50bb7e77feccfe3f0a521714de6a153387d3847bd94542e2a974bb05121
           - name: kind
             value: task
         resolver: bundles
@@ -367,7 +367,7 @@ spec:
           - name: name
             value: clair-scan
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3.2@sha256:8fad4c2e2f470f82ee43d6b2ac72327b4d9c6e9cb514a678911c1c9359c29894
+            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3.2@sha256:312fb4d135e351bde38bcb14a7897b238d0aac19703b4e507c105f12b57836f1
           - name: kind
             value: task
         resolver: bundles
@@ -392,7 +392,7 @@ spec:
           - name: name
             value: ecosystem-cert-preflight-checks
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:88f4fd6d7812a3c46f120f3035974f5fb8cb06b5e3e927badf6e8370f1516a88
+            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:3c4f60ebda2225eff6a6bc387d9bbd443f1264d756bf385f97cc684992e904a0
           - name: kind
             value: task
         resolver: bundles
@@ -420,7 +420,7 @@ spec:
           - name: name
             value: sast-snyk-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:0ebf28a0abd5a167438d4628938a74ade6f00a44a4b7ed1cfa9cfc57a5b24748
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:2db846fa5d8e593b4def045693d79ebd01802ec6edeea0f6003a23167a8a078e
           - name: kind
             value: task
         resolver: bundles
@@ -475,7 +475,7 @@ spec:
           - name: name
             value: sast-shell-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:3cbb3535af6e7d4396858179a6427caaffb2e68775594795692fc01f28ae313f
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:fc685d6f7dfb7c9ab2f2db38bbe2c8d383407847350ccd8b96352322c487b13c
           - name: kind
             value: task
         resolver: bundles
@@ -503,7 +503,7 @@ spec:
           - name: name
             value: sast-unicode-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:223812001607b07f0e07d56bef7b7d619144e660c0c57f21ddd44ce0c8c4785b
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:5807ffe3a0cca5cf970076bbc7a404642cc6e3eebe64e9e5e6a4f20da740bf73
           - name: kind
             value: task
         resolver: bundles
@@ -567,7 +567,7 @@ spec:
           - name: name
             value: rpms-signature-scan
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2.1@sha256:237c54b069d16c3785d1302f19be309aa6c0ae2313d446e30cb74671e07ca676
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2.1@sha256:e42148ce79713de1536d15161c0a7b8bfb138bc046ad663098d9b56d5810be47
           - name: kind
             value: task
         resolver: bundles
@@ -598,7 +598,7 @@ spec:
       taskRef:
         params:
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:14766aebbf6f4739e1b7dde0406dcba2d1e300170d3b084f23df9fb074d87dc3
+            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:d34a3789505f829493636a265eb04790695dba84bbb2bb716a7551a6911f2816
           - name: name
             value: slack-webhook-notification
           - name: kind

--- a/pipelines/common.yaml
+++ b/pipelines/common.yaml
@@ -238,7 +238,7 @@ spec:
           - name: name
             value: prefetch-dependencies-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:3dc78afbf3a441e0280067433cb28ea3d2d0088ec214c73bf063f145b4f273ef
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:7e84b01526b6a50b920c0f456c8d95d6c5c2f7b81109ea772e1dcf7aba14bfa5
           - name: kind
             value: task
         resolver: bundles
@@ -300,7 +300,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.9@sha256:77007259cc87f32d63d2c201226aadaab98313cfd4e02b46abc243c4d2cc27bd
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.10@sha256:1eaac50bb7e77feccfe3f0a521714de6a153387d3847bd94542e2a974bb05121
           - name: kind
             value: task
         resolver: bundles
@@ -392,7 +392,7 @@ spec:
           - name: name
             value: clair-scan
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3.2@sha256:8fad4c2e2f470f82ee43d6b2ac72327b4d9c6e9cb514a678911c1c9359c29894
+            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3.2@sha256:312fb4d135e351bde38bcb14a7897b238d0aac19703b4e507c105f12b57836f1
           - name: kind
             value: task
         resolver: bundles
@@ -417,7 +417,7 @@ spec:
           - name: name
             value: ecosystem-cert-preflight-checks
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:88f4fd6d7812a3c46f120f3035974f5fb8cb06b5e3e927badf6e8370f1516a88
+            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:3c4f60ebda2225eff6a6bc387d9bbd443f1264d756bf385f97cc684992e904a0
           - name: kind
             value: task
         resolver: bundles
@@ -445,7 +445,7 @@ spec:
           - name: name
             value: sast-snyk-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:0ebf28a0abd5a167438d4628938a74ade6f00a44a4b7ed1cfa9cfc57a5b24748
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:2db846fa5d8e593b4def045693d79ebd01802ec6edeea0f6003a23167a8a078e
           - name: kind
             value: task
         resolver: bundles
@@ -500,7 +500,7 @@ spec:
           - name: name
             value: sast-shell-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:3cbb3535af6e7d4396858179a6427caaffb2e68775594795692fc01f28ae313f
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:fc685d6f7dfb7c9ab2f2db38bbe2c8d383407847350ccd8b96352322c487b13c
           - name: kind
             value: task
         resolver: bundles
@@ -528,7 +528,7 @@ spec:
           - name: name
             value: sast-unicode-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:223812001607b07f0e07d56bef7b7d619144e660c0c57f21ddd44ce0c8c4785b
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:5807ffe3a0cca5cf970076bbc7a404642cc6e3eebe64e9e5e6a4f20da740bf73
           - name: kind
             value: task
         resolver: bundles
@@ -592,7 +592,7 @@ spec:
           - name: name
             value: rpms-signature-scan
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2.1@sha256:237c54b069d16c3785d1302f19be309aa6c0ae2313d446e30cb74671e07ca676
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2.1@sha256:e42148ce79713de1536d15161c0a7b8bfb138bc046ad663098d9b56d5810be47
           - name: kind
             value: task
         resolver: bundles
@@ -623,7 +623,7 @@ spec:
       taskRef:
         params:
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:14766aebbf6f4739e1b7dde0406dcba2d1e300170d3b084f23df9fb074d87dc3
+            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:d34a3789505f829493636a265eb04790695dba84bbb2bb716a7551a6911f2816
           - name: name
             value: slack-webhook-notification
           - name: kind

--- a/update-tekton-task-bundles.sh
+++ b/update-tekton-task-bundles.sh
@@ -6,25 +6,37 @@
 
 set -euo pipefail
 
+migrate=${MIGRATE:-false}
+
+function log() {
+    echo "${1}" >&2
+}
+
+if [[ "${migrate}" == "true" ]]; then
+    log "INFO: Enabling task version migration"
+else
+    log "INFO: Disabling task version migration (set MIGRATE=true to enable)"
+fi
+
 # Detect OS and set sed in-place flag accordingly
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  SED_INPLACE=(-i '')
+    SED_INPLACE=(-i '')
 else
-  SED_INPLACE=(-i)
+    SED_INPLACE=(-i)
 fi
 
 if [[ -z "$*" ]]; then
-    echo "error: at least one pipeline file is required" >&2
+    log "ERROR: at least one pipeline file is required"
     exit 1
 fi
 
-FILES=( "$@" )
+FILES=("$@")
 
 # Find existing image references
-OLD_REFS="$(\
-    yq '... | select(has("resolver")) | .params // [] | .[] | select(.name == "bundle") | .value'  "${FILES[@]}" | \
-    grep -v -- '---' | \
-    sort -u \
+OLD_REFS="$(
+    yq '... | select(has("resolver")) | .params // [] | .[] | select(.name == "bundle") | .value' "${FILES[@]}" |
+        grep -v -- '---' |
+        sort -u
 )"
 
 # Array to store migration data
@@ -32,12 +44,16 @@ migration_data=()
 
 # Find updates for image references
 for old_ref in ${OLD_REFS}; do
+    log "==="
+    log "INFO: Checking reference ${old_ref}"
+
     repo_tag="${old_ref%@*}"
     repo="${repo_tag%:*}"
     old_tag="${repo_tag##*:}"
     old_digest="${old_ref##*@}"
 
-    tags=$(skopeo list-tags "docker://${repo}" | yq '.Tags[]' | tr -d '"')
+    log "INFO: Fetching tags for repository ${repo}"
+    tags=$(skopeo list-tags "docker://${repo}" | yq '.Tags[]')
 
     main_tags=$(echo "$tags" | grep -E '^[0-9]+(\.[0-9]+)*$')
     latest_main_tag=$(echo "$main_tags" | sort -V | tail -n1)
@@ -47,13 +63,24 @@ for old_ref in ${OLD_REFS}; do
         task_name=${task_name#task-}
 
         # Get new digest for the latest tag
-        new_digest=$(skopeo inspect "docker://${repo}:${latest_main_tag}" | yq '.Digest' | tr -d '"')
+        new_digest=$(skopeo inspect --no-tags "docker://${repo}:${latest_main_tag}" | yq '.Digest')
 
         # Find which files contain this reference
         for file in "${FILES[@]}"; do
+            if [[ -L ${file} ]]; then
+                log "INFO: Skipping symlink file ${file}"
+                continue
+            fi
+
+            log "INFO: Checking pipeline file ${file}"
+
             if grep -q "${old_ref}" "${file}" 2>/dev/null; then
+                if [[ "${migrate}" == "true" ]]; then
+                    old_tag=${latest_main_tag}
+                fi
                 # Create JSON object for this migration
-                migration_entry=$(cat <<EOF
+                migration_entry=$(
+                    cat <<EOF
   {
     "depName": "${repo}",
     "link": "https://github.com/konflux-ci/build-definitions/tree/main/task/${task_name}",
@@ -66,27 +93,46 @@ for old_ref in ${OLD_REFS}; do
     "depTypes": ["tekton-bundle"]
   }
 EOF
-)
+                )
                 migration_data+=("$migration_entry")
             fi
         done
     fi
 
-    new_digest=$(skopeo inspect "docker://${repo}:${old_tag}" | yq '.Digest')
-    new_ref="${repo}:${old_tag}@${new_digest}"
+    target_tag=${old_tag}
+    if [[ "${migrate}" == "true" ]]; then
+        target_tag=${latest_main_tag}
+    fi
+    new_digest=$(skopeo inspect --no-tags "docker://${repo}:${target_tag}" | yq '.Digest')
+    new_ref="${repo}:${target_tag}@${new_digest}"
+    if [[ ${old_ref} == "${new_ref}" ]]; then
+        log "INFO: Reference is already up-to-date. Continuing."
+        continue
+    fi
     for file in "${FILES[@]}"; do
-        sed "${SED_INPLACE[@]}" -e "s!${old_ref}!${new_ref}!g" "$file"
+        if [[ -L ${file} ]]; then
+            log "INFO: skipping symlink file ${file}"
+            continue
+        fi
+        if ! grep -q "${old_ref}" "${file}" 2>/dev/null; then
+            log "INFO: skipping file ${file} not containing ${old_ref}"
+            continue
+        fi
+        log "INFO: Updating pipeline file ${file}"
+        sed "${SED_INPLACE[@]}" -e "s!${old_ref}!${new_ref}!g" "${file}"
     done
 done
 
 # Output migration data in JSON format
 if [[ ${#migration_data[@]} -gt 0 ]]; then
-    echo "["
-    for i in "${!migration_data[@]}"; do
-        echo "${migration_data[$i]}"
-        if [[ $i -lt $((${#migration_data[@]} - 1)) ]]; then
-            echo ","
-        fi
-    done
-    echo "]"
+    (
+        echo "["
+        for i in "${!migration_data[@]}"; do
+            echo "${migration_data[$i]}"
+            if [[ $i -lt $((${#migration_data[@]} - 1)) ]]; then
+                echo ","
+            fi
+        done
+        echo "]"
+    ) | jq
 fi


### PR DESCRIPTION
Migrations were confirmed to not require configuration updates.

This also adds a `MIGRATE=true` env to the script to allow the script to handle these version updates.

Closes #1079
Closes #1080
Closes #1081
Closes #1082
Closes #1083

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Updated the pipeline bundle update script usage examples, including direct invocation changes and a new MIGRATE=true example.

* **Updates**
  * Bumped pinned Tekton task bundle digests/tags across multiple pipelines, including build, security scan, preflight, and failure notification steps.
  * Improved the pipeline bundle update script with clearer logging and error handling, plus enhanced support for migrating pipeline version references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->