### PR TITLE
chore: add metadata task to `runAfter`

### DIFF
--- a/pipelines/common-stage.yaml
+++ b/pipelines/common-stage.yaml
@@ -288,6 +288,7 @@ spec:
             - $(tasks.fetch-product-metadata.results.image-labels[*])
       runAfter:
         - prefetch-dependencies
+        - fetch-product-metadata
       taskRef:
         params:
           - name: name

--- a/pipelines/common.yaml
+++ b/pipelines/common.yaml
@@ -313,6 +313,7 @@ spec:
             - $(tasks.fetch-product-metadata.results.image-labels[*])
       runAfter:
         - prefetch-dependencies
+        - fetch-product-metadata
       taskRef:
         params:
           - name: name


### PR DESCRIPTION
Not required since `build-images` already waits for it since it relies on its results, but makes the dependency clearer (and ought to also show the dependency in the flowchart in the console).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated image build sequencing to wait for product metadata to be available before starting.
  * Improved pipeline reliability by ensuring image builds use the latest metadata and labeling information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->