### PR TITLE
ran the latest update to pull in new tasks and migrations

### DIFF
--- a/pipelines/common-base.yaml
+++ b/pipelines/common-base.yaml
@@ -180,7 +180,7 @@ spec:
           - name: name
             value: init
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4.3@sha256:b8465d543589b1238f6911626657f5766e279a0f33a5f70de68073401e031184
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4.3@sha256:15d3d4a7e5c70b068103a9d4c6ba2e049db8896709fc45c0bd4be49c134b0989
           - name: kind
             value: task
         resolver: bundles
@@ -209,7 +209,7 @@ spec:
           - name: name
             value: git-clone-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2.5@sha256:510daad5648d37936b9b2c599a35c8e59b7389de8e1a4e58f6c6d079957d730d
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2.5@sha256:799e6093832d194293168240a6e2209479cfaad33de51d57bfcbcfead97ed038
           - name: kind
             value: task
         resolver: bundles
@@ -235,7 +235,7 @@ spec:
           - name: name
             value: prefetch-dependencies-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.6.0@sha256:01158b939522c276ba36804c2cc7ef641a572fb6c27f001819ea287dd708cd13
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.7.1@sha256:75109b17ba38c211fafe6aa676868e16c00e451db7b61bc939b0e7cd6035900b
           - name: kind
             value: task
         resolver: bundles
@@ -299,7 +299,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.10.7@sha256:94f129a97242995d647b1d23a5d53e7022e0c3dc00aff764a4da4be263263cbf
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.11.1@sha256:effb57d4bf055adc2bacc196eb181575717bfc91bf3cbcdf022ca7e9adf26d81
           - name: kind
             value: task
         resolver: bundles
@@ -321,7 +321,7 @@ spec:
           - name: name
             value: build-image-index
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3.1@sha256:a355355b7fcd0ba8de4ba85a162a2e6893f53236b943f79cb03ae0ae9c5ef53c
+            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3.1@sha256:b00c9e68e96d41c95c725805e378ccdda44e0a1e55b69eae3f9d1f0ba1a6a493
           - name: kind
             value: task
         resolver: bundles
@@ -342,7 +342,7 @@ spec:
           - name: name
             value: source-build-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:6081c4167e87a9167f7db4cda9ff0110607b7b9fc404c3daa076247475a4affa
+            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:93f1df1d3b51b20974ca25e1f75704dcd989c4e088994a34784d8759e46ce49f
           - name: kind
             value: task
         resolver: bundles
@@ -416,7 +416,7 @@ spec:
           - name: name
             value: ecosystem-cert-preflight-checks
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:27c9760ad11c74ad010d9615ee15348e3674843166acb7686929b3ef6840416c
+            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:e438f3104d706f73812994953d3d0a9c62ac8e4a372d86337ff26bbca9902709
           - name: kind
             value: task
         resolver: bundles
@@ -444,7 +444,7 @@ spec:
           - name: name
             value: sast-snyk-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:eba24f5d9f4b18aa71e523b9b3dbcf22982aa4b018824260a090b19dfc9abf6f
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:b78e9c05c5126613eddee53f2f3534a9b86bfca17d903599f2fa465b7938e241
           - name: kind
             value: task
         resolver: bundles
@@ -499,7 +499,7 @@ spec:
           - name: name
             value: sast-shell-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:61b27e6ad5daba761d41bb37efb790ed98380603fd4fe2f86d156def5bd72ecc
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:beb05ae2fad733783b3b17e05871e0eaf527a07c904cf3fb2cb551025007eec1
           - name: kind
             value: task
         resolver: bundles
@@ -527,7 +527,7 @@ spec:
           - name: name
             value: sast-unicode-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:eb9d5392f215cb8b52b16382098cac4885b1e6cd989f88ebd83fdb234d283eb9
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:d09f717cb84f0699a531773bc498745deef2c006a81918aa73b3be6d2f4778bd
           - name: kind
             value: task
         resolver: bundles
@@ -551,7 +551,7 @@ spec:
           - name: name
             value: apply-tags
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:6387614ae4f9efa8abb7c4175db0ce5d958bc2b90665b4704880e46fbe0535bf
+            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:da0cff2a36f07087798cd5f577b15f3d9e6dd4d3d08956227b298362e08ecc37
           - name: kind
             value: task
         resolver: bundles
@@ -574,7 +574,7 @@ spec:
           - name: name
             value: push-dockerfile-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3.1@sha256:5393bada94051f02aa971ff773b130928e01ac595b9ce3bbbd69899751ed8222
+            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3.1@sha256:350a144c002df3dd0312be1a2a1ec4d3efd5a78ec3eb57b6157de2fb766b30c9
           - name: kind
             value: task
         resolver: bundles
@@ -591,7 +591,7 @@ spec:
           - name: name
             value: rpms-signature-scan
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2.1@sha256:ccb77d1bf7627fc6241a59ed42bb6e5707a8682754fe8ae18f2cfdddbcf29275
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2.1@sha256:41ff5935eae38c717552af6ef82b01c2ec16e64eb7131a8002d14ff3746f0f35
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common-fbc.yaml
+++ b/pipelines/common-fbc.yaml
@@ -193,7 +193,7 @@ spec:
           - name: name
             value: init
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4.3@sha256:b8465d543589b1238f6911626657f5766e279a0f33a5f70de68073401e031184
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4.3@sha256:15d3d4a7e5c70b068103a9d4c6ba2e049db8896709fc45c0bd4be49c134b0989
           - name: kind
             value: task
         resolver: bundles
@@ -214,7 +214,7 @@ spec:
           - name: name
             value: git-clone-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2.5@sha256:510daad5648d37936b9b2c599a35c8e59b7389de8e1a4e58f6c6d079957d730d
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2.5@sha256:799e6093832d194293168240a6e2209479cfaad33de51d57bfcbcfead97ed038
           - name: kind
             value: task
         resolver: bundles
@@ -292,7 +292,7 @@ spec:
           - name: name
             value: prefetch-dependencies-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.6.0@sha256:01158b939522c276ba36804c2cc7ef641a572fb6c27f001819ea287dd708cd13
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.7.1@sha256:75109b17ba38c211fafe6aa676868e16c00e451db7b61bc939b0e7cd6035900b
           - name: kind
             value: task
         resolver: bundles
@@ -352,7 +352,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.10.7@sha256:94f129a97242995d647b1d23a5d53e7022e0c3dc00aff764a4da4be263263cbf
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.11.1@sha256:effb57d4bf055adc2bacc196eb181575717bfc91bf3cbcdf022ca7e9adf26d81
           - name: kind
             value: task
         resolver: bundles
@@ -372,7 +372,7 @@ spec:
           - name: name
             value: build-image-index
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3.1@sha256:a355355b7fcd0ba8de4ba85a162a2e6893f53236b943f79cb03ae0ae9c5ef53c
+            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3.1@sha256:b00c9e68e96d41c95c725805e378ccdda44e0a1e55b69eae3f9d1f0ba1a6a493
           - name: kind
             value: task
         resolver: bundles
@@ -413,7 +413,7 @@ spec:
           - name: name
             value: apply-tags
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:6387614ae4f9efa8abb7c4175db0ce5d958bc2b90665b4704880e46fbe0535bf
+            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:da0cff2a36f07087798cd5f577b15f3d9e6dd4d3d08956227b298362e08ecc37
           - name: kind
             value: task
         resolver: bundles
@@ -480,7 +480,7 @@ spec:
           - name: name
             value: fbc-fips-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:935adb61a5c9be0f619edc8838771ad3fe08cf17689094aeaaeac493af2a2115
+            value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:11f4adee71143d1bb8504bb96edfa868be9624e0f1758fc299d7a9a86f30e8e0
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common-oci-ta.yaml
+++ b/pipelines/common-oci-ta.yaml
@@ -188,7 +188,7 @@ spec:
           - name: name
             value: init
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4.3@sha256:b8465d543589b1238f6911626657f5766e279a0f33a5f70de68073401e031184
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4.3@sha256:15d3d4a7e5c70b068103a9d4c6ba2e049db8896709fc45c0bd4be49c134b0989
           - name: kind
             value: task
         resolver: bundles
@@ -209,7 +209,7 @@ spec:
           - name: name
             value: git-clone-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2.5@sha256:510daad5648d37936b9b2c599a35c8e59b7389de8e1a4e58f6c6d079957d730d
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2.5@sha256:799e6093832d194293168240a6e2209479cfaad33de51d57bfcbcfead97ed038
           - name: kind
             value: task
         resolver: bundles
@@ -235,7 +235,7 @@ spec:
           - name: name
             value: prefetch-dependencies-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.6.0@sha256:01158b939522c276ba36804c2cc7ef641a572fb6c27f001819ea287dd708cd13
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.7.1@sha256:75109b17ba38c211fafe6aa676868e16c00e451db7b61bc939b0e7cd6035900b
           - name: kind
             value: task
         resolver: bundles
@@ -292,7 +292,7 @@ spec:
           - name: name
             value: buildah-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.10.7@sha256:f07fccbe8d952ba2e9e5f3b8b8bfcda2cc8037d5153cf19da7d5ed0bb8b431a8
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.11.1@sha256:55d38c7fc0224ace8d3adfc2a2c060a032d9f2657b5c7b6553890919d590fc7e
           - name: kind
             value: task
         resolver: bundles
@@ -314,7 +314,7 @@ spec:
           - name: name
             value: build-image-index
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3.1@sha256:a355355b7fcd0ba8de4ba85a162a2e6893f53236b943f79cb03ae0ae9c5ef53c
+            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3.1@sha256:b00c9e68e96d41c95c725805e378ccdda44e0a1e55b69eae3f9d1f0ba1a6a493
           - name: kind
             value: task
         resolver: bundles
@@ -335,7 +335,7 @@ spec:
           - name: name
             value: source-build-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:6081c4167e87a9167f7db4cda9ff0110607b7b9fc404c3daa076247475a4affa
+            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:93f1df1d3b51b20974ca25e1f75704dcd989c4e088994a34784d8759e46ce49f
           - name: kind
             value: task
         resolver: bundles
@@ -399,7 +399,7 @@ spec:
           - name: name
             value: ecosystem-cert-preflight-checks
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:27c9760ad11c74ad010d9615ee15348e3674843166acb7686929b3ef6840416c
+            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:e438f3104d706f73812994953d3d0a9c62ac8e4a372d86337ff26bbca9902709
           - name: kind
             value: task
         resolver: bundles
@@ -427,7 +427,7 @@ spec:
           - name: name
             value: sast-snyk-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:eba24f5d9f4b18aa71e523b9b3dbcf22982aa4b018824260a090b19dfc9abf6f
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:b78e9c05c5126613eddee53f2f3534a9b86bfca17d903599f2fa465b7938e241
           - name: kind
             value: task
         resolver: bundles
@@ -477,7 +477,7 @@ spec:
           - name: name
             value: sast-shell-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:61b27e6ad5daba761d41bb37efb790ed98380603fd4fe2f86d156def5bd72ecc
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:beb05ae2fad733783b3b17e05871e0eaf527a07c904cf3fb2cb551025007eec1
           - name: kind
             value: task
         resolver: bundles
@@ -505,7 +505,7 @@ spec:
           - name: name
             value: sast-unicode-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:eb9d5392f215cb8b52b16382098cac4885b1e6cd989f88ebd83fdb234d283eb9
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:d09f717cb84f0699a531773bc498745deef2c006a81918aa73b3be6d2f4778bd
           - name: kind
             value: task
         resolver: bundles
@@ -529,7 +529,7 @@ spec:
           - name: name
             value: apply-tags
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:6387614ae4f9efa8abb7c4175db0ce5d958bc2b90665b4704880e46fbe0535bf
+            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:da0cff2a36f07087798cd5f577b15f3d9e6dd4d3d08956227b298362e08ecc37
           - name: kind
             value: task
         resolver: bundles
@@ -552,7 +552,7 @@ spec:
           - name: name
             value: push-dockerfile-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3.1@sha256:5393bada94051f02aa971ff773b130928e01ac595b9ce3bbbd69899751ed8222
+            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3.1@sha256:350a144c002df3dd0312be1a2a1ec4d3efd5a78ec3eb57b6157de2fb766b30c9
           - name: kind
             value: task
         resolver: bundles
@@ -569,7 +569,7 @@ spec:
           - name: name
             value: rpms-signature-scan
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2.1@sha256:ccb77d1bf7627fc6241a59ed42bb6e5707a8682754fe8ae18f2cfdddbcf29275
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2.1@sha256:41ff5935eae38c717552af6ef82b01c2ec16e64eb7131a8002d14ff3746f0f35
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common-stage.yaml
+++ b/pipelines/common-stage.yaml
@@ -161,7 +161,7 @@ spec:
           - name: name
             value: init
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4.3@sha256:b8465d543589b1238f6911626657f5766e279a0f33a5f70de68073401e031184
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4.3@sha256:15d3d4a7e5c70b068103a9d4c6ba2e049db8896709fc45c0bd4be49c134b0989
           - name: kind
             value: task
         resolver: bundles
@@ -184,7 +184,7 @@ spec:
           - name: name
             value: git-clone-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2.5@sha256:510daad5648d37936b9b2c599a35c8e59b7389de8e1a4e58f6c6d079957d730d
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2.5@sha256:799e6093832d194293168240a6e2209479cfaad33de51d57bfcbcfead97ed038
           - name: kind
             value: task
         resolver: bundles
@@ -225,7 +225,7 @@ spec:
           - name: name
             value: prefetch-dependencies-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.6.0@sha256:01158b939522c276ba36804c2cc7ef641a572fb6c27f001819ea287dd708cd13
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.7.1@sha256:75109b17ba38c211fafe6aa676868e16c00e451db7b61bc939b0e7cd6035900b
           - name: kind
             value: task
         resolver: bundles
@@ -294,7 +294,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.10.7@sha256:94f129a97242995d647b1d23a5d53e7022e0c3dc00aff764a4da4be263263cbf
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.11.1@sha256:effb57d4bf055adc2bacc196eb181575717bfc91bf3cbcdf022ca7e9adf26d81
           - name: kind
             value: task
         resolver: bundles
@@ -316,7 +316,7 @@ spec:
           - name: name
             value: build-image-index
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3.1@sha256:a355355b7fcd0ba8de4ba85a162a2e6893f53236b943f79cb03ae0ae9c5ef53c
+            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3.1@sha256:b00c9e68e96d41c95c725805e378ccdda44e0a1e55b69eae3f9d1f0ba1a6a493
           - name: kind
             value: task
         resolver: bundles
@@ -337,7 +337,7 @@ spec:
           - name: name
             value: source-build-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:6081c4167e87a9167f7db4cda9ff0110607b7b9fc404c3daa076247475a4affa
+            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:93f1df1d3b51b20974ca25e1f75704dcd989c4e088994a34784d8759e46ce49f
           - name: kind
             value: task
         resolver: bundles
@@ -411,7 +411,7 @@ spec:
           - name: name
             value: ecosystem-cert-preflight-checks
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:27c9760ad11c74ad010d9615ee15348e3674843166acb7686929b3ef6840416c
+            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:e438f3104d706f73812994953d3d0a9c62ac8e4a372d86337ff26bbca9902709
           - name: kind
             value: task
         resolver: bundles
@@ -439,7 +439,7 @@ spec:
           - name: name
             value: sast-snyk-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:eba24f5d9f4b18aa71e523b9b3dbcf22982aa4b018824260a090b19dfc9abf6f
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:b78e9c05c5126613eddee53f2f3534a9b86bfca17d903599f2fa465b7938e241
           - name: kind
             value: task
         resolver: bundles
@@ -494,7 +494,7 @@ spec:
           - name: name
             value: sast-shell-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:61b27e6ad5daba761d41bb37efb790ed98380603fd4fe2f86d156def5bd72ecc
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:beb05ae2fad733783b3b17e05871e0eaf527a07c904cf3fb2cb551025007eec1
           - name: kind
             value: task
         resolver: bundles
@@ -522,7 +522,7 @@ spec:
           - name: name
             value: sast-unicode-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:eb9d5392f215cb8b52b16382098cac4885b1e6cd989f88ebd83fdb234d283eb9
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:d09f717cb84f0699a531773bc498745deef2c006a81918aa73b3be6d2f4778bd
           - name: kind
             value: task
         resolver: bundles
@@ -546,7 +546,7 @@ spec:
           - name: name
             value: apply-tags
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:6387614ae4f9efa8abb7c4175db0ce5d958bc2b90665b4704880e46fbe0535bf
+            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:da0cff2a36f07087798cd5f577b15f3d9e6dd4d3d08956227b298362e08ecc37
           - name: kind
             value: task
         resolver: bundles
@@ -569,7 +569,7 @@ spec:
           - name: name
             value: push-dockerfile-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3.1@sha256:5393bada94051f02aa971ff773b130928e01ac595b9ce3bbbd69899751ed8222
+            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3.1@sha256:350a144c002df3dd0312be1a2a1ec4d3efd5a78ec3eb57b6157de2fb766b30c9
           - name: kind
             value: task
         resolver: bundles
@@ -586,7 +586,7 @@ spec:
           - name: name
             value: rpms-signature-scan
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2.1@sha256:ccb77d1bf7627fc6241a59ed42bb6e5707a8682754fe8ae18f2cfdddbcf29275
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2.1@sha256:41ff5935eae38c717552af6ef82b01c2ec16e64eb7131a8002d14ff3746f0f35
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/common.yaml
+++ b/pipelines/common.yaml
@@ -180,7 +180,7 @@ spec:
           - name: name
             value: init
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4.3@sha256:b8465d543589b1238f6911626657f5766e279a0f33a5f70de68073401e031184
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4.3@sha256:15d3d4a7e5c70b068103a9d4c6ba2e049db8896709fc45c0bd4be49c134b0989
           - name: kind
             value: task
         resolver: bundles
@@ -209,7 +209,7 @@ spec:
           - name: name
             value: git-clone-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2.5@sha256:510daad5648d37936b9b2c599a35c8e59b7389de8e1a4e58f6c6d079957d730d
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2.5@sha256:799e6093832d194293168240a6e2209479cfaad33de51d57bfcbcfead97ed038
           - name: kind
             value: task
         resolver: bundles
@@ -250,7 +250,7 @@ spec:
           - name: name
             value: prefetch-dependencies-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.6.0@sha256:01158b939522c276ba36804c2cc7ef641a572fb6c27f001819ea287dd708cd13
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.7.1@sha256:75109b17ba38c211fafe6aa676868e16c00e451db7b61bc939b0e7cd6035900b
           - name: kind
             value: task
         resolver: bundles
@@ -319,7 +319,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.10.7@sha256:94f129a97242995d647b1d23a5d53e7022e0c3dc00aff764a4da4be263263cbf
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.11.1@sha256:effb57d4bf055adc2bacc196eb181575717bfc91bf3cbcdf022ca7e9adf26d81
           - name: kind
             value: task
         resolver: bundles
@@ -341,7 +341,7 @@ spec:
           - name: name
             value: build-image-index
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3.1@sha256:a355355b7fcd0ba8de4ba85a162a2e6893f53236b943f79cb03ae0ae9c5ef53c
+            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3.1@sha256:b00c9e68e96d41c95c725805e378ccdda44e0a1e55b69eae3f9d1f0ba1a6a493
           - name: kind
             value: task
         resolver: bundles
@@ -362,7 +362,7 @@ spec:
           - name: name
             value: source-build-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:6081c4167e87a9167f7db4cda9ff0110607b7b9fc404c3daa076247475a4affa
+            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:93f1df1d3b51b20974ca25e1f75704dcd989c4e088994a34784d8759e46ce49f
           - name: kind
             value: task
         resolver: bundles
@@ -436,7 +436,7 @@ spec:
           - name: name
             value: ecosystem-cert-preflight-checks
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:27c9760ad11c74ad010d9615ee15348e3674843166acb7686929b3ef6840416c
+            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:e438f3104d706f73812994953d3d0a9c62ac8e4a372d86337ff26bbca9902709
           - name: kind
             value: task
         resolver: bundles
@@ -464,7 +464,7 @@ spec:
           - name: name
             value: sast-snyk-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:eba24f5d9f4b18aa71e523b9b3dbcf22982aa4b018824260a090b19dfc9abf6f
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:b78e9c05c5126613eddee53f2f3534a9b86bfca17d903599f2fa465b7938e241
           - name: kind
             value: task
         resolver: bundles
@@ -519,7 +519,7 @@ spec:
           - name: name
             value: sast-shell-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:61b27e6ad5daba761d41bb37efb790ed98380603fd4fe2f86d156def5bd72ecc
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:beb05ae2fad733783b3b17e05871e0eaf527a07c904cf3fb2cb551025007eec1
           - name: kind
             value: task
         resolver: bundles
@@ -547,7 +547,7 @@ spec:
           - name: name
             value: sast-unicode-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:eb9d5392f215cb8b52b16382098cac4885b1e6cd989f88ebd83fdb234d283eb9
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:d09f717cb84f0699a531773bc498745deef2c006a81918aa73b3be6d2f4778bd
           - name: kind
             value: task
         resolver: bundles
@@ -571,7 +571,7 @@ spec:
           - name: name
             value: apply-tags
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:6387614ae4f9efa8abb7c4175db0ce5d958bc2b90665b4704880e46fbe0535bf
+            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:da0cff2a36f07087798cd5f577b15f3d9e6dd4d3d08956227b298362e08ecc37
           - name: kind
             value: task
         resolver: bundles
@@ -594,7 +594,7 @@ spec:
           - name: name
             value: push-dockerfile-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3.1@sha256:5393bada94051f02aa971ff773b130928e01ac595b9ce3bbbd69899751ed8222
+            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3.1@sha256:350a144c002df3dd0312be1a2a1ec4d3efd5a78ec3eb57b6157de2fb766b30c9
           - name: kind
             value: task
         resolver: bundles
@@ -611,7 +611,7 @@ spec:
           - name: name
             value: rpms-signature-scan
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2.1@sha256:ccb77d1bf7627fc6241a59ed42bb6e5707a8682754fe8ae18f2cfdddbcf29275
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2.1@sha256:41ff5935eae38c717552af6ef82b01c2ec16e64eb7131a8002d14ff3746f0f35
           - name: kind
             value: task
         resolver: bundles

--- a/test/fbc/multicluster-global-hub-operator-rh/catalog.yaml
+++ b/test/fbc/multicluster-global-hub-operator-rh/catalog.yaml
@@ -18,6 +18,8 @@ schema: olm.channel
 entries:
   - name: multicluster-global-hub-operator-rh.v1.8.0
     skipRange: ">=1.7.0 <1.8.0"
+  - name: multicluster-global-hub-operator-rh.v1.8.1
+    replaces: multicluster-global-hub-operator-rh.v1.8.0
 name: release-1.8
 package: multicluster-global-hub-operator-rh
 schema: olm.channel
@@ -88,9 +90,7 @@ properties:
         certified: "false"
         containerImage: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-rhel9-operator@sha256:dc7f88f17f004bb0da88bb6e5603c7d345c6c56ae8da0654c3c451d04987c54e
         createdAt: "2026-01-21T06:18:42Z"
-        description:
-          Manages the installation and upgrade of the Multicluster Global
-          Hub.
+        description: Manages the installation and upgrade of the Multicluster Global Hub.
         features.operators.openshift.io/cnf: "false"
         features.operators.openshift.io/cni: "false"
         features.operators.openshift.io/csi: "false"
@@ -102,15 +102,10 @@ properties:
         features.operators.openshift.io/token-auth-azure: "false"
         features.operators.openshift.io/token-auth-gcp: "false"
         olm.skipRange: ">=1.6.0 <1.7.0"
-        operatorframework.io/initialization-resource:
-          '{"apiVersion":"operator.open-cluster-management.io/v1alpha4",
-          "kind":"MulticlusterGlobalHub","metadata":{"name":"multiclusterglobalhub","namespace":"multicluster-global-hub"},
-          "spec": {}}'
+        operatorframework.io/initialization-resource: '{"apiVersion":"operator.open-cluster-management.io/v1alpha4", "kind":"MulticlusterGlobalHub","metadata":{"name":"multiclusterglobalhub","namespace":"multicluster-global-hub"}, "spec": {}}'
         operatorframework.io/suggested-namespace: multicluster-global-hub
         operators.openshift.io/infrastructure-features: '["disconnected", "fips"]'
-        operators.openshift.io/valid-subscription:
-          '["OpenShift Platform Plus", "Red
-          Hat Advanced Cluster Management for Kubernetes"]'
+        operators.openshift.io/valid-subscription: '["OpenShift Platform Plus", "Red Hat Advanced Cluster Management for Kubernetes"]'
         operators.operatorframework.io/builder: operator-sdk-v1.34.1
         operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
         repository: https://github.com/stolostron/multicluster-global-hub
@@ -118,9 +113,7 @@ properties:
       apiServiceDefinitions: {}
       crdDescriptions:
         owned:
-          - description:
-              ManagedClusterMigration is a global hub resource that allows
-              you to migrate managed clusters from one hub to another
+          - description: ManagedClusterMigration is a global hub resource that allows you to migrate managed clusters from one hub to another
             displayName: Managed Cluster Migration
             kind: ManagedClusterMigration
             name: managedclustermigrations.global-hub.open-cluster-management.io
@@ -129,54 +122,33 @@ properties:
                 name: multicluster-global-hub-manager
                 version: v1
             specDescriptors:
-              - description:
-                  From specifies the source hub cluster from which the managed
-                  clusters originate.
+              - description: From specifies the source hub cluster from which the managed clusters originate.
                 displayName: From
                 path: from
-              - description:
-                  IncludedManagedClusters is an explicit list of managed clusters
-                  to include in the migration operation. This field is mutually exclusive
-                  with IncludedManagedClustersPlacementRef.
+              - description: IncludedManagedClusters is an explicit list of managed clusters to include in the migration operation. This field is mutually exclusive with IncludedManagedClustersPlacementRef.
                 displayName: Included Managed Clusters
                 path: includedManagedClusters
-              - description:
-                  IncludedManagedClustersPlacementRef specifies the name of a
-                  Placement resource that determines which managed clusters are included
-                  in the migration operation. The referenced Placement must be defined in
-                  the global hub agent namespace of the source hub cluster, such as "multicluster-global-hub"
-                  or "multicluster-global-hub-agent". This field is mutually exclusive with
-                  IncludedManagedClusters.
+              - description: IncludedManagedClustersPlacementRef specifies the name of a Placement resource that determines which managed clusters are included in the migration operation. The referenced Placement must be defined in the global hub agent namespace of the source hub cluster, such as "multicluster-global-hub" or "multicluster-global-hub-agent". This field is mutually exclusive with IncludedManagedClusters.
                 displayName: Included Managed Clusters Placement
                 path: includedManagedClustersPlacementRef
-              - description:
-                  SupportedConfigs defines additional configuration options for
-                  the migration
+              - description: SupportedConfigs defines additional configuration options for the migration
                 displayName: Supported Configs
                 path: supportedConfigs
-              - description:
-                  StageTimeout defines the timeout duration for each migration
-                  stage
+              - description: StageTimeout defines the timeout duration for each migration stage
                 displayName: Stage Timeout
                 path: supportedConfigs.stageTimeout
-              - description:
-                  To specifies the target hub cluster to which the managed clusters
-                  will be migrated.
+              - description: To specifies the target hub cluster to which the managed clusters will be migrated.
                 displayName: To
                 path: to
             statusDescriptors:
-              - description:
-                  Conditions represents the latest available observations of
-                  the current state
+              - description: Conditions represents the latest available observations of the current state
                 displayName: Conditions
                 path: conditions
               - description: Phase represents the current phase of the migration
                 displayName: Phase
                 path: phase
             version: v1alpha1
-          - description:
-              MulticlusterGlobalHubAgent is the Schema for the multiclusterglobalhubagents
-              API
+          - description: MulticlusterGlobalHubAgent is the Schema for the multiclusterglobalhubagents API
             displayName: Multicluster Global Hub Agent
             kind: MulticlusterGlobalHubAgent
             name: multiclusterglobalhubagents.operator.open-cluster-management.io
@@ -185,16 +157,12 @@ properties:
                 name: multicluster-global-hub-operator
                 version: v1
             specDescriptors:
-              - description:
-                  ImagePullPolicy specifies the pull policy of the multicluster
-                  global hub agent image
+              - description: ImagePullPolicy specifies the pull policy of the multicluster global hub agent image
                 displayName: Image Pull Policy
                 path: imagePullPolicy
                 x-descriptors:
                   - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
-              - description:
-                  ImagePullSecret specifies the pull secret of the multicluster
-                  global hub agent image
+              - description: ImagePullSecret specifies the pull secret of the multicluster global hub agent image
                 displayName: Image Pull Secret
                 path: imagePullSecret
                 x-descriptors:
@@ -202,24 +170,15 @@ properties:
               - description: Tolerations causes all components to tolerate any taints
                 displayName: Tolerations
                 path: tolerations
-              - description:
-                  TransportConfigSecretName specifies the secret which is used
-                  to connect to the global hub Kafka. You can get kafka.yaml content using
-                  `tools/generate-kafka-config.sh` from the global hub environment. Then
-                  you can create the secret in the current environment by running `kubectl
-                  create secret generic transport-config -n "multicluster-global-hub" --from-file=kafka.yaml="./kafka.yaml"`
+              - description: TransportConfigSecretName specifies the secret which is used to connect to the global hub Kafka. You can get kafka.yaml content using `tools/generate-kafka-config.sh` from the global hub environment. Then you can create the secret in the current environment by running `kubectl create secret generic transport-config -n "multicluster-global-hub" --from-file=kafka.yaml="./kafka.yaml"`
                 displayName: Transport Config Secret Name
                 path: transportConfigSecretName
             statusDescriptors:
-              - description:
-                  Conditions represents the latest available observations of
-                  the current state
+              - description: Conditions represents the latest available observations of the current state
                 displayName: Conditions
                 path: conditions
             version: v1alpha1
-          - description:
-              MulticlusterGlobalHub defines the configuration for an instance
-              of the multiCluster global hub
+          - description: MulticlusterGlobalHub defines the configuration for an instance of the multiCluster global hub
             displayName: Multicluster Global Hub
             kind: MulticlusterGlobalHub
             name: multiclusterglobalhubs.operator.open-cluster-management.io
@@ -228,9 +187,7 @@ properties:
                 name: multicluster-global-hub-operator
                 version: v1
             specDescriptors:
-              - description:
-                  "AvailabilityType specifies deployment replication for improved
-                  availability. Options are: Basic and High (default)"
+              - description: "AvailabilityType specifies deployment replication for improved availability. Options are: Basic and High (default)"
                 displayName: Availability Configuration
                 path: availabilityConfig
                 x-descriptors:
@@ -239,33 +196,22 @@ properties:
               - description: DataLayerSpec can be configured to use a different data layer
                 displayName: Data Layer Spec
                 path: dataLayer
-              - description:
-                  EnableMetrics enables the metrics for the global hub created
-                  kafka and postgres components. If the user provides the kafka and postgres,
-                  then the enablemetrics variable is useless.
+              - description: EnableMetrics enables the metrics for the global hub created kafka and postgres components. If the user provides the kafka and postgres, then the enablemetrics variable is useless.
                 displayName: Enable Metrics
                 path: enableMetrics
                 x-descriptors:
                   - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-              - description:
-                  ImagePullPolicy specifies the pull policy of the multicluster
-                  global hub images
+              - description: ImagePullPolicy specifies the pull policy of the multicluster global hub images
                 displayName: Image Pull Policy
                 path: imagePullPolicy
                 x-descriptors:
                   - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
-              - description:
-                  ImagePullSecret specifies the pull secret of the multicluster
-                  global hub images
+              - description: ImagePullSecret specifies the pull secret of the multicluster global hub images
                 displayName: Image Pull Secret
                 path: imagePullSecret
                 x-descriptors:
                   - urn:alm:descriptor:io.kubernetes:Secret
-              - description:
-                  InstallAgentOnLocal determines whether deploy the Global Hub
-                  Agent on the local hub cluster or not. If set to true, the Global Hub
-                  Agent will be installed on the local hub cluster only. If set to false,
-                  the Global Hub Agent will not be installed on the local hub cluster.
+              - description: InstallAgentOnLocal determines whether deploy the Global Hub Agent on the local hub cluster or not. If set to true, the Global Hub Agent will be installed on the local hub cluster only. If set to false, the Global Hub Agent will not be installed on the local hub cluster.
                 displayName: Install Agent On Local
                 path: installAgentOnLocal
                 x-descriptors:
@@ -274,9 +220,7 @@ properties:
                 displayName: Tolerations
                 path: tolerations
             statusDescriptors:
-              - description:
-                  Conditions represents the latest available observations of
-                  the current state
+              - description: Conditions represents the latest available observations of the current state
                 displayName: Conditions
                 path: conditions
             version: v1alpha4
@@ -436,9 +380,7 @@ properties:
         certified: "false"
         containerImage: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-rhel9-operator@sha256:76440d8be5b38b31cdc012857301fedf51f92e688817bf00cc25dcd1739d65fd
         createdAt: "2026-01-21T06:18:42Z"
-        description:
-          Manages the installation and upgrade of the Multicluster Global
-          Hub.
+        description: Manages the installation and upgrade of the Multicluster Global Hub.
         features.operators.openshift.io/cnf: "false"
         features.operators.openshift.io/cni: "false"
         features.operators.openshift.io/csi: "false"
@@ -450,15 +392,10 @@ properties:
         features.operators.openshift.io/token-auth-azure: "false"
         features.operators.openshift.io/token-auth-gcp: "false"
         olm.skipRange: ">=1.6.0 <1.7.0"
-        operatorframework.io/initialization-resource:
-          '{"apiVersion":"operator.open-cluster-management.io/v1alpha4",
-          "kind":"MulticlusterGlobalHub","metadata":{"name":"multiclusterglobalhub","namespace":"multicluster-global-hub"},
-          "spec": {}}'
+        operatorframework.io/initialization-resource: '{"apiVersion":"operator.open-cluster-management.io/v1alpha4", "kind":"MulticlusterGlobalHub","metadata":{"name":"multiclusterglobalhub","namespace":"multicluster-global-hub"}, "spec": {}}'
         operatorframework.io/suggested-namespace: multicluster-global-hub
         operators.openshift.io/infrastructure-features: '["disconnected", "fips"]'
-        operators.openshift.io/valid-subscription:
-          '["OpenShift Platform Plus", "Red
-          Hat Advanced Cluster Management for Kubernetes"]'
+        operators.openshift.io/valid-subscription: '["OpenShift Platform Plus", "Red Hat Advanced Cluster Management for Kubernetes"]'
         operators.operatorframework.io/builder: operator-sdk-v1.34.1
         operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
         repository: https://github.com/stolostron/multicluster-global-hub
@@ -466,9 +403,7 @@ properties:
       apiServiceDefinitions: {}
       crdDescriptions:
         owned:
-          - description:
-              ManagedClusterMigration is a global hub resource that allows
-              you to migrate managed clusters from one hub to another
+          - description: ManagedClusterMigration is a global hub resource that allows you to migrate managed clusters from one hub to another
             displayName: Managed Cluster Migration
             kind: ManagedClusterMigration
             name: managedclustermigrations.global-hub.open-cluster-management.io
@@ -477,54 +412,33 @@ properties:
                 name: multicluster-global-hub-manager
                 version: v1
             specDescriptors:
-              - description:
-                  From specifies the source hub cluster from which the managed
-                  clusters originate.
+              - description: From specifies the source hub cluster from which the managed clusters originate.
                 displayName: From
                 path: from
-              - description:
-                  IncludedManagedClusters is an explicit list of managed clusters
-                  to include in the migration operation. This field is mutually exclusive
-                  with IncludedManagedClustersPlacementRef.
+              - description: IncludedManagedClusters is an explicit list of managed clusters to include in the migration operation. This field is mutually exclusive with IncludedManagedClustersPlacementRef.
                 displayName: Included Managed Clusters
                 path: includedManagedClusters
-              - description:
-                  IncludedManagedClustersPlacementRef specifies the name of a
-                  Placement resource that determines which managed clusters are included
-                  in the migration operation. The referenced Placement must be defined in
-                  the global hub agent namespace of the source hub cluster, such as "multicluster-global-hub"
-                  or "multicluster-global-hub-agent". This field is mutually exclusive with
-                  IncludedManagedClusters.
+              - description: IncludedManagedClustersPlacementRef specifies the name of a Placement resource that determines which managed clusters are included in the migration operation. The referenced Placement must be defined in the global hub agent namespace of the source hub cluster, such as "multicluster-global-hub" or "multicluster-global-hub-agent". This field is mutually exclusive with IncludedManagedClusters.
                 displayName: Included Managed Clusters Placement
                 path: includedManagedClustersPlacementRef
-              - description:
-                  SupportedConfigs defines additional configuration options for
-                  the migration
+              - description: SupportedConfigs defines additional configuration options for the migration
                 displayName: Supported Configs
                 path: supportedConfigs
-              - description:
-                  StageTimeout defines the timeout duration for each migration
-                  stage
+              - description: StageTimeout defines the timeout duration for each migration stage
                 displayName: Stage Timeout
                 path: supportedConfigs.stageTimeout
-              - description:
-                  To specifies the target hub cluster to which the managed clusters
-                  will be migrated.
+              - description: To specifies the target hub cluster to which the managed clusters will be migrated.
                 displayName: To
                 path: to
             statusDescriptors:
-              - description:
-                  Conditions represents the latest available observations of
-                  the current state
+              - description: Conditions represents the latest available observations of the current state
                 displayName: Conditions
                 path: conditions
               - description: Phase represents the current phase of the migration
                 displayName: Phase
                 path: phase
             version: v1alpha1
-          - description:
-              MulticlusterGlobalHubAgent is the Schema for the multiclusterglobalhubagents
-              API
+          - description: MulticlusterGlobalHubAgent is the Schema for the multiclusterglobalhubagents API
             displayName: Multicluster Global Hub Agent
             kind: MulticlusterGlobalHubAgent
             name: multiclusterglobalhubagents.operator.open-cluster-management.io
@@ -533,16 +447,12 @@ properties:
                 name: multicluster-global-hub-operator
                 version: v1
             specDescriptors:
-              - description:
-                  ImagePullPolicy specifies the pull policy of the multicluster
-                  global hub agent image
+              - description: ImagePullPolicy specifies the pull policy of the multicluster global hub agent image
                 displayName: Image Pull Policy
                 path: imagePullPolicy
                 x-descriptors:
                   - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
-              - description:
-                  ImagePullSecret specifies the pull secret of the multicluster
-                  global hub agent image
+              - description: ImagePullSecret specifies the pull secret of the multicluster global hub agent image
                 displayName: Image Pull Secret
                 path: imagePullSecret
                 x-descriptors:
@@ -550,24 +460,15 @@ properties:
               - description: Tolerations causes all components to tolerate any taints
                 displayName: Tolerations
                 path: tolerations
-              - description:
-                  TransportConfigSecretName specifies the secret which is used
-                  to connect to the global hub Kafka. You can get kafka.yaml content using
-                  `tools/generate-kafka-config.sh` from the global hub environment. Then
-                  you can create the secret in the current environment by running `kubectl
-                  create secret generic transport-config -n "multicluster-global-hub" --from-file=kafka.yaml="./kafka.yaml"`
+              - description: TransportConfigSecretName specifies the secret which is used to connect to the global hub Kafka. You can get kafka.yaml content using `tools/generate-kafka-config.sh` from the global hub environment. Then you can create the secret in the current environment by running `kubectl create secret generic transport-config -n "multicluster-global-hub" --from-file=kafka.yaml="./kafka.yaml"`
                 displayName: Transport Config Secret Name
                 path: transportConfigSecretName
             statusDescriptors:
-              - description:
-                  Conditions represents the latest available observations of
-                  the current state
+              - description: Conditions represents the latest available observations of the current state
                 displayName: Conditions
                 path: conditions
             version: v1alpha1
-          - description:
-              MulticlusterGlobalHub defines the configuration for an instance
-              of the multiCluster global hub
+          - description: MulticlusterGlobalHub defines the configuration for an instance of the multiCluster global hub
             displayName: Multicluster Global Hub
             kind: MulticlusterGlobalHub
             name: multiclusterglobalhubs.operator.open-cluster-management.io
@@ -576,9 +477,7 @@ properties:
                 name: multicluster-global-hub-operator
                 version: v1
             specDescriptors:
-              - description:
-                  "AvailabilityType specifies deployment replication for improved
-                  availability. Options are: Basic and High (default)"
+              - description: "AvailabilityType specifies deployment replication for improved availability. Options are: Basic and High (default)"
                 displayName: Availability Configuration
                 path: availabilityConfig
                 x-descriptors:
@@ -587,33 +486,22 @@ properties:
               - description: DataLayerSpec can be configured to use a different data layer
                 displayName: Data Layer Spec
                 path: dataLayer
-              - description:
-                  EnableMetrics enables the metrics for the global hub created
-                  kafka and postgres components. If the user provides the kafka and postgres,
-                  then the enablemetrics variable is useless.
+              - description: EnableMetrics enables the metrics for the global hub created kafka and postgres components. If the user provides the kafka and postgres, then the enablemetrics variable is useless.
                 displayName: Enable Metrics
                 path: enableMetrics
                 x-descriptors:
                   - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-              - description:
-                  ImagePullPolicy specifies the pull policy of the multicluster
-                  global hub images
+              - description: ImagePullPolicy specifies the pull policy of the multicluster global hub images
                 displayName: Image Pull Policy
                 path: imagePullPolicy
                 x-descriptors:
                   - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
-              - description:
-                  ImagePullSecret specifies the pull secret of the multicluster
-                  global hub images
+              - description: ImagePullSecret specifies the pull secret of the multicluster global hub images
                 displayName: Image Pull Secret
                 path: imagePullSecret
                 x-descriptors:
                   - urn:alm:descriptor:io.kubernetes:Secret
-              - description:
-                  InstallAgentOnLocal determines whether deploy the Global Hub
-                  Agent on the local hub cluster or not. If set to true, the Global Hub
-                  Agent will be installed on the local hub cluster only. If set to false,
-                  the Global Hub Agent will not be installed on the local hub cluster.
+              - description: InstallAgentOnLocal determines whether deploy the Global Hub Agent on the local hub cluster or not. If set to true, the Global Hub Agent will be installed on the local hub cluster only. If set to false, the Global Hub Agent will not be installed on the local hub cluster.
                 displayName: Install Agent On Local
                 path: installAgentOnLocal
                 x-descriptors:
@@ -622,9 +510,7 @@ properties:
                 displayName: Tolerations
                 path: tolerations
             statusDescriptors:
-              - description:
-                  Conditions represents the latest available observations of
-                  the current state
+              - description: Conditions represents the latest available observations of the current state
                 displayName: Conditions
                 path: conditions
             version: v1alpha4
@@ -784,9 +670,7 @@ properties:
         certified: "false"
         containerImage: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-rhel9-operator@sha256:f2725194c3b0d8c4f9b4408376993bbf691941ccd94e51dea01447f7ac64973b
         createdAt: "2026-03-24T13:21:36Z"
-        description:
-          Manages the installation and upgrade of the Multicluster Global
-          Hub.
+        description: Manages the installation and upgrade of the Multicluster Global Hub.
         features.operators.openshift.io/cnf: "false"
         features.operators.openshift.io/cni: "false"
         features.operators.openshift.io/csi: "false"
@@ -798,15 +682,10 @@ properties:
         features.operators.openshift.io/token-auth-azure: "false"
         features.operators.openshift.io/token-auth-gcp: "false"
         olm.skipRange: ">=1.7.0 <1.8.0"
-        operatorframework.io/initialization-resource:
-          '{"apiVersion":"operator.open-cluster-management.io/v1alpha4",
-          "kind":"MulticlusterGlobalHub","metadata":{"name":"multiclusterglobalhub","namespace":"multicluster-global-hub"},
-          "spec": {}}'
+        operatorframework.io/initialization-resource: '{"apiVersion":"operator.open-cluster-management.io/v1alpha4", "kind":"MulticlusterGlobalHub","metadata":{"name":"multiclusterglobalhub","namespace":"multicluster-global-hub"}, "spec": {}}'
         operatorframework.io/suggested-namespace: multicluster-global-hub
         operators.openshift.io/infrastructure-features: '["disconnected", "fips"]'
-        operators.openshift.io/valid-subscription:
-          '["OpenShift Platform Plus", "Red
-          Hat Advanced Cluster Management for Kubernetes"]'
+        operators.openshift.io/valid-subscription: '["OpenShift Platform Plus", "Red Hat Advanced Cluster Management for Kubernetes"]'
         operators.operatorframework.io/builder: operator-sdk-v1.34.1
         operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
         repository: https://github.com/stolostron/multicluster-global-hub
@@ -814,9 +693,7 @@ properties:
       apiServiceDefinitions: {}
       crdDescriptions:
         owned:
-          - description:
-              ManagedClusterMigration is a global hub resource that allows
-              you to migrate managed clusters from one hub to another
+          - description: ManagedClusterMigration is a global hub resource that allows you to migrate managed clusters from one hub to another
             displayName: Managed Cluster Migration
             kind: ManagedClusterMigration
             name: managedclustermigrations.global-hub.open-cluster-management.io
@@ -825,54 +702,33 @@ properties:
                 name: multicluster-global-hub-manager
                 version: v1
             specDescriptors:
-              - description:
-                  From specifies the source hub cluster from which the managed
-                  clusters originate.
+              - description: From specifies the source hub cluster from which the managed clusters originate.
                 displayName: From
                 path: from
-              - description:
-                  IncludedManagedClusters is an explicit list of managed clusters
-                  to include in the migration operation. This field is mutually exclusive
-                  with IncludedManagedClustersPlacementRef.
+              - description: IncludedManagedClusters is an explicit list of managed clusters to include in the migration operation. This field is mutually exclusive with IncludedManagedClustersPlacementRef.
                 displayName: Included Managed Clusters
                 path: includedManagedClusters
-              - description:
-                  IncludedManagedClustersPlacementRef specifies the name of a
-                  Placement resource that determines which managed clusters are included
-                  in the migration operation. The referenced Placement must be defined in
-                  the global hub agent namespace of the source hub cluster, such as "multicluster-global-hub"
-                  or "multicluster-global-hub-agent". This field is mutually exclusive with
-                  IncludedManagedClusters.
+              - description: IncludedManagedClustersPlacementRef specifies the name of a Placement resource that determines which managed clusters are included in the migration operation. The referenced Placement must be defined in the global hub agent namespace of the source hub cluster, such as "multicluster-global-hub" or "multicluster-global-hub-agent". This field is mutually exclusive with IncludedManagedClusters.
                 displayName: Included Managed Clusters Placement
                 path: includedManagedClustersPlacementRef
-              - description:
-                  SupportedConfigs defines additional configuration options for
-                  the migration
+              - description: SupportedConfigs defines additional configuration options for the migration
                 displayName: Supported Configs
                 path: supportedConfigs
-              - description:
-                  StageTimeout defines the timeout duration for each migration
-                  stage
+              - description: StageTimeout defines the timeout duration for each migration stage
                 displayName: Stage Timeout
                 path: supportedConfigs.stageTimeout
-              - description:
-                  To specifies the target hub cluster to which the managed clusters
-                  will be migrated.
+              - description: To specifies the target hub cluster to which the managed clusters will be migrated.
                 displayName: To
                 path: to
             statusDescriptors:
-              - description:
-                  Conditions represents the latest available observations of
-                  the current state
+              - description: Conditions represents the latest available observations of the current state
                 displayName: Conditions
                 path: conditions
               - description: Phase represents the current phase of the migration
                 displayName: Phase
                 path: phase
             version: v1alpha1
-          - description:
-              MulticlusterGlobalHubAgent is the Schema for the multiclusterglobalhubagents
-              API
+          - description: MulticlusterGlobalHubAgent is the Schema for the multiclusterglobalhubagents API
             displayName: Multicluster Global Hub Agent
             kind: MulticlusterGlobalHubAgent
             name: multiclusterglobalhubagents.operator.open-cluster-management.io
@@ -881,16 +737,12 @@ properties:
                 name: multicluster-global-hub-operator
                 version: v1
             specDescriptors:
-              - description:
-                  ImagePullPolicy specifies the pull policy of the multicluster
-                  global hub agent image
+              - description: ImagePullPolicy specifies the pull policy of the multicluster global hub agent image
                 displayName: Image Pull Policy
                 path: imagePullPolicy
                 x-descriptors:
                   - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
-              - description:
-                  ImagePullSecret specifies the pull secret of the multicluster
-                  global hub agent image
+              - description: ImagePullSecret specifies the pull secret of the multicluster global hub agent image
                 displayName: Image Pull Secret
                 path: imagePullSecret
                 x-descriptors:
@@ -898,24 +750,15 @@ properties:
               - description: Tolerations causes all components to tolerate any taints
                 displayName: Tolerations
                 path: tolerations
-              - description:
-                  TransportConfigSecretName specifies the secret which is used
-                  to connect to the global hub Kafka. You can get kafka.yaml content using
-                  `tools/generate-kafka-config.sh` from the global hub environment. Then
-                  you can create the secret in the current environment by running `kubectl
-                  create secret generic transport-config -n "multicluster-global-hub" --from-file=kafka.yaml="./kafka.yaml"`
+              - description: TransportConfigSecretName specifies the secret which is used to connect to the global hub Kafka. You can get kafka.yaml content using `tools/generate-kafka-config.sh` from the global hub environment. Then you can create the secret in the current environment by running `kubectl create secret generic transport-config -n "multicluster-global-hub" --from-file=kafka.yaml="./kafka.yaml"`
                 displayName: Transport Config Secret Name
                 path: transportConfigSecretName
             statusDescriptors:
-              - description:
-                  Conditions represents the latest available observations of
-                  the current state
+              - description: Conditions represents the latest available observations of the current state
                 displayName: Conditions
                 path: conditions
             version: v1alpha1
-          - description:
-              MulticlusterGlobalHub defines the configuration for an instance
-              of the multiCluster global hub
+          - description: MulticlusterGlobalHub defines the configuration for an instance of the multiCluster global hub
             displayName: Multicluster Global Hub
             kind: MulticlusterGlobalHub
             name: multiclusterglobalhubs.operator.open-cluster-management.io
@@ -924,9 +767,7 @@ properties:
                 name: multicluster-global-hub-operator
                 version: v1
             specDescriptors:
-              - description:
-                  "AvailabilityType specifies deployment replication for improved
-                  availability. Options are: Basic and High (default)"
+              - description: "AvailabilityType specifies deployment replication for improved availability. Options are: Basic and High (default)"
                 displayName: Availability Configuration
                 path: availabilityConfig
                 x-descriptors:
@@ -935,33 +776,22 @@ properties:
               - description: DataLayerSpec can be configured to use a different data layer
                 displayName: Data Layer Spec
                 path: dataLayer
-              - description:
-                  EnableMetrics enables the metrics for the global hub created
-                  kafka and postgres components. If the user provides the kafka and postgres,
-                  then the enablemetrics variable is useless.
+              - description: EnableMetrics enables the metrics for the global hub created kafka and postgres components. If the user provides the kafka and postgres, then the enablemetrics variable is useless.
                 displayName: Enable Metrics
                 path: enableMetrics
                 x-descriptors:
                   - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-              - description:
-                  ImagePullPolicy specifies the pull policy of the multicluster
-                  global hub images
+              - description: ImagePullPolicy specifies the pull policy of the multicluster global hub images
                 displayName: Image Pull Policy
                 path: imagePullPolicy
                 x-descriptors:
                   - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
-              - description:
-                  ImagePullSecret specifies the pull secret of the multicluster
-                  global hub images
+              - description: ImagePullSecret specifies the pull secret of the multicluster global hub images
                 displayName: Image Pull Secret
                 path: imagePullSecret
                 x-descriptors:
                   - urn:alm:descriptor:io.kubernetes:Secret
-              - description:
-                  InstallAgentOnLocal determines whether deploy the Global Hub
-                  Agent on the local hub cluster or not. If set to true, the Global Hub
-                  Agent will be installed on the local hub cluster only. If set to false,
-                  the Global Hub Agent will not be installed on the local hub cluster.
+              - description: InstallAgentOnLocal determines whether deploy the Global Hub Agent on the local hub cluster or not. If set to true, the Global Hub Agent will be installed on the local hub cluster only. If set to false, the Global Hub Agent will not be installed on the local hub cluster.
                 displayName: Install Agent On Local
                 path: installAgentOnLocal
                 x-descriptors:
@@ -970,9 +800,7 @@ properties:
                 displayName: Tolerations
                 path: tolerations
             statusDescriptors:
-              - description:
-                  Conditions represents the latest available observations of
-                  the current state
+              - description: Conditions represents the latest available observations of the current state
                 displayName: Conditions
                 path: conditions
             version: v1alpha4
@@ -1063,5 +891,295 @@ relatedImages:
   - image: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-rhel9-operator@sha256:f2725194c3b0d8c4f9b4408376993bbf691941ccd94e51dea01447f7ac64973b
     name: ""
   - image: registry.redhat.io/rhel9/postgresql-16@sha256:c2ac59c92d6629864210164d6899ddc021be8933d4a5ec262c659a38a20b670d
+    name: postgresql
+schema: olm.bundle
+---
+image: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-operator-bundle@sha256:9fa9b4a4984fa2c8057ec7375a613a302bf6a99ec5c6059dfb43e35fb3a29ae8
+name: multicluster-global-hub-operator-rh.v1.8.1
+package: multicluster-global-hub-operator-rh
+properties:
+  - type: olm.gvk
+    value:
+      group: global-hub.open-cluster-management.io
+      kind: ManagedClusterMigration
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: operator.open-cluster-management.io
+      kind: MulticlusterGlobalHub
+      version: v1alpha4
+  - type: olm.gvk
+    value:
+      group: operator.open-cluster-management.io
+      kind: MulticlusterGlobalHubAgent
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: multicluster-global-hub-operator-rh
+      version: 1.8.1
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "global-hub.open-cluster-management.io/v1alpha1",
+              "kind": "ManagedClusterMigration",
+              "metadata": {
+                "name": "migration-sample"
+              },
+              "spec": {}
+            },
+            {
+              "apiVersion": "operator.open-cluster-management.io/v1alpha1",
+              "kind": "MulticlusterGlobalHubAgent",
+              "metadata": {
+                "name": "multiclusterglobalhubagent"
+              },
+              "spec": {
+                "transportConfigSecretName": "transport-config"
+              }
+            },
+            {
+              "apiVersion": "operator.open-cluster-management.io/v1alpha4",
+              "kind": "MulticlusterGlobalHub",
+              "metadata": {
+                "name": "multiclusterglobalhub"
+              },
+              "spec": {
+                "dataLayer": {
+                  "postgres": {
+                    "retention": "18m"
+                  }
+                }
+              }
+            }
+          ]
+        capabilities: Seamless Upgrades
+        categories: Integration & Delivery,OpenShift Optional
+        certified: "false"
+        containerImage: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-rhel9-operator@sha256:fa39e1d8ad329ebe341598df25dae4a388b34c28056732ed519ca8c3acb265c7
+        createdAt: "2026-03-24T13:21:36Z"
+        description: Manages the installation and upgrade of the Multicluster Global Hub.
+        features.operators.openshift.io/cnf: "false"
+        features.operators.openshift.io/cni: "false"
+        features.operators.openshift.io/csi: "false"
+        features.operators.openshift.io/disconnected: "true"
+        features.operators.openshift.io/fips-compliant: "true"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        olm.skipRange: '>=1.7.0 <1.8.0'
+        operatorframework.io/initialization-resource: '{"apiVersion":"operator.open-cluster-management.io/v1alpha4", "kind":"MulticlusterGlobalHub","metadata":{"name":"multiclusterglobalhub","namespace":"multicluster-global-hub"}, "spec": {}}'
+        operatorframework.io/suggested-namespace: multicluster-global-hub
+        operators.openshift.io/infrastructure-features: '["disconnected", "fips"]'
+        operators.openshift.io/valid-subscription: '["OpenShift Platform Plus", "Red Hat Advanced Cluster Management for Kubernetes"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.34.1
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+        repository: https://github.com/stolostron/multicluster-global-hub
+        support: Red Hat
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: ManagedClusterMigration is a global hub resource that allows you to migrate managed clusters from one hub to another
+            displayName: Managed Cluster Migration
+            kind: ManagedClusterMigration
+            name: managedclustermigrations.global-hub.open-cluster-management.io
+            resources:
+              - kind: Deployment
+                name: multicluster-global-hub-manager
+                version: v1
+            specDescriptors:
+              - description: From specifies the source hub cluster from which the managed clusters originate.
+                displayName: From
+                path: from
+              - description: IncludedManagedClusters is an explicit list of managed clusters to include in the migration operation. This field is mutually exclusive with IncludedManagedClustersPlacementRef.
+                displayName: Included Managed Clusters
+                path: includedManagedClusters
+              - description: IncludedManagedClustersPlacementRef specifies the name of a Placement resource that determines which managed clusters are included in the migration operation. The referenced Placement must be defined in the global hub agent namespace of the source hub cluster, such as "multicluster-global-hub" or "multicluster-global-hub-agent". This field is mutually exclusive with IncludedManagedClusters.
+                displayName: Included Managed Clusters Placement
+                path: includedManagedClustersPlacementRef
+              - description: SupportedConfigs defines additional configuration options for the migration
+                displayName: Supported Configs
+                path: supportedConfigs
+              - description: StageTimeout defines the timeout duration for each migration stage
+                displayName: Stage Timeout
+                path: supportedConfigs.stageTimeout
+              - description: To specifies the target hub cluster to which the managed clusters will be migrated.
+                displayName: To
+                path: to
+            statusDescriptors:
+              - description: Conditions represents the latest available observations of the current state
+                displayName: Conditions
+                path: conditions
+              - description: Phase represents the current phase of the migration
+                displayName: Phase
+                path: phase
+            version: v1alpha1
+          - description: MulticlusterGlobalHubAgent is the Schema for the multiclusterglobalhubagents API
+            displayName: Multicluster Global Hub Agent
+            kind: MulticlusterGlobalHubAgent
+            name: multiclusterglobalhubagents.operator.open-cluster-management.io
+            resources:
+              - kind: Deployment
+                name: multicluster-global-hub-operator
+                version: v1
+            specDescriptors:
+              - description: ImagePullPolicy specifies the pull policy of the multicluster global hub agent image
+                displayName: Image Pull Policy
+                path: imagePullPolicy
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
+              - description: ImagePullSecret specifies the pull secret of the multicluster global hub agent image
+                displayName: Image Pull Secret
+                path: imagePullSecret
+                x-descriptors:
+                  - urn:alm:descriptor:io.kubernetes:Secret
+              - description: Tolerations causes all components to tolerate any taints
+                displayName: Tolerations
+                path: tolerations
+              - description: TransportConfigSecretName specifies the secret which is used to connect to the global hub Kafka. You can get kafka.yaml content using `tools/generate-kafka-config.sh` from the global hub environment. Then you can create the secret in the current environment by running `kubectl create secret generic transport-config -n "multicluster-global-hub" --from-file=kafka.yaml="./kafka.yaml"`
+                displayName: Transport Config Secret Name
+                path: transportConfigSecretName
+            statusDescriptors:
+              - description: Conditions represents the latest available observations of the current state
+                displayName: Conditions
+                path: conditions
+            version: v1alpha1
+          - description: MulticlusterGlobalHub defines the configuration for an instance of the multiCluster global hub
+            displayName: Multicluster Global Hub
+            kind: MulticlusterGlobalHub
+            name: multiclusterglobalhubs.operator.open-cluster-management.io
+            resources:
+              - kind: Deployment
+                name: multicluster-global-hub-operator
+                version: v1
+            specDescriptors:
+              - description: 'AvailabilityType specifies deployment replication for improved availability. Options are: Basic and High (default)'
+                displayName: Availability Configuration
+                path: availabilityConfig
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:select:High
+                  - urn:alm:descriptor:com.tectonic.ui:select:Basic
+              - description: DataLayerSpec can be configured to use a different data layer
+                displayName: Data Layer Spec
+                path: dataLayer
+              - description: EnableMetrics enables the metrics for the global hub created kafka and postgres components. If the user provides the kafka and postgres, then the enablemetrics variable is useless.
+                displayName: Enable Metrics
+                path: enableMetrics
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+              - description: ImagePullPolicy specifies the pull policy of the multicluster global hub images
+                displayName: Image Pull Policy
+                path: imagePullPolicy
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
+              - description: ImagePullSecret specifies the pull secret of the multicluster global hub images
+                displayName: Image Pull Secret
+                path: imagePullSecret
+                x-descriptors:
+                  - urn:alm:descriptor:io.kubernetes:Secret
+              - description: InstallAgentOnLocal determines whether deploy the Global Hub Agent on the local hub cluster or not. If set to true, the Global Hub Agent will be installed on the local hub cluster only. If set to false, the Global Hub Agent will not be installed on the local hub cluster.
+                displayName: Install Agent On Local
+                path: installAgentOnLocal
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+              - description: Tolerations causes all components to tolerate any taints
+                displayName: Tolerations
+                path: tolerations
+            statusDescriptors:
+              - description: Conditions represents the latest available observations of the current state
+                displayName: Conditions
+                path: conditions
+            version: v1alpha4
+      description: |
+        The Multicluster Global Hub Operator contains the components of multicluster global hub. The Operator deploys all of the required components for global multicluster management. The components include `multicluster-global-hub-manager` and `multicluster-global-hub-grafana` in the global hub cluster and `multicluster-global-hub-agent` in the managed hub clusters.
+        The Operator also deploys the strimzi kafka and crunchy postgres if you do not bring your own kafka and postgres.
+
+        ## Prerequisites
+        - Red Hat Advanced Cluster Management for Kubernetes needs to be installed. You can find the support matrix in the official document.
+
+        ## How to Install
+        Install the Multicluster Global Hub Operator by following the instructions that are displayed after you select the Install button.
+        A pod will be created in `multicluster-global-hub` namespace:
+        ```
+        $ kubectl get pods -n multicluster-global-hub
+        NAME                                                             READY   STATUS    RESTARTS   AGE
+        multicluster-global-hub-operator-5ccbbc878d-98fdp                1/1     Running   0          19s
+        ```
+        The operator is now providing new Custom Resources Definitions: `multiclusterglobalhubs.operator.open-cluster-management.io`
+
+        ## Using the Multicluster Global Hub Operator
+        After installed the operator, create an instance of the MulticlusterGlobalHub resource to instantiate the Multicluster Global Hub.
+        Once an instance of the MulticlusterGlobalHub is created, the following pods are created in the `multicluster-global-hub` namespace:
+        ```
+        $ kubectl get pods -n multicluster-global-hub
+        NAME                                                    READY   STATUS    RESTARTS   AGE
+        amq-streams-cluster-operator-v2.6.0-2-f49bf7559-569mw   1/1     Running   0          22m
+        kafka-entity-operator-68dcd446f4-pg257                  3/3     Running   0          19m
+        kafka-kafka-0                                           1/1     Running   0          20m
+        kafka-kafka-1                                           1/1     Running   0          20m
+        kafka-kafka-2                                           1/1     Running   0          20m
+        multicluster-global-hub-grafana-5b7cfb6876-5rcnn        2/2     Running   0          19m
+        multicluster-global-hub-grafana-5b7cfb6876-wq99v        2/2     Running   0          19m
+        multicluster-global-hub-manager-7f56d78c49-hzfvw        1/1     Running   0          19m
+        multicluster-global-hub-manager-7f56d78c49-wbkzl        1/1     Running   0          19m
+        multicluster-global-hub-operator-768bd5bd4f-59xjd       1/1     Running   0          22m
+        multicluster-global-hub-postgresql-0                    2/2     Running   0          22m
+        ```
+        ## Documentation
+        For documentation about installing and using the Multicluster GlobalHub Operator with Red Hat Advanced Cluster Management for
+        Kubernetes, see [Multicluser GlobalHub Documentation](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.17/html-single/multicluster_global_hub/index#doc-wrapper) in the Red Hat Advanced Cluster Management
+        documentation.
+
+        ## Support & Troubleshooting
+        Product support, which includes Support Cases, Product Pages, and Knowledgebase articles, is available when you have
+        a [Red Hat Advanced Cluster Management](https://www.redhat.com/en/technologies/management/advanced-cluster-management)
+        subscription.
+      displayName: Multicluster Global Hub Operator
+      installModes:
+        - supported: true
+          type: OwnNamespace
+        - supported: true
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: false
+          type: AllNamespaces
+      keywords:
+        - multicluster-global-hub
+        - multiple-hubs
+      labels:
+        operatorframework.io/arch.amd64: supported
+        operatorframework.io/arch.arm64: supported
+        operatorframework.io/arch.ppc64le: supported
+        operatorframework.io/arch.s390x: supported
+        operatorframework.io/os.linux: supported
+      links:
+        - name: Multicluster Global Hub Operator
+          url: https://github.com/stolostron/multicluster-global-hub
+      maintainers:
+        - email: acm-contact@redhat.com
+          name: acm-contact
+      maturity: release-1.8
+      provider:
+        name: Red Hat, Inc
+        url: https://github.com/stolostron/multicluster-global-hub
+relatedImages:
+  - image: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-agent-rhel9@sha256:6e4e3f0a27ca00397d9395daa167f17ef86de34c46415478a360ed930ef5e24c
+    name: multicluster-global-hub-agent
+  - image: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-grafana-rhel9@sha256:71e6b91840fba2e4dd6aa0a0cf1c55d541d70edcbbf2570f49a5ef692402e942
+    name: grafana
+  - image: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-manager-rhel9@sha256:1cf00cedf84993d85254453a6fee5b8ee6e9d4d062768b682b42b0e63012ea73
+    name: multicluster-global-hub-manager
+  - image: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-operator-bundle@sha256:9fa9b4a4984fa2c8057ec7375a613a302bf6a99ec5c6059dfb43e35fb3a29ae8
+    name: ""
+  - image: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-postgres-exporter-rhel9@sha256:835cf9de4889141d00e450958f772aa85bade7693f629b6b20a8fc6394555428
+    name: postgres-exporter
+  - image: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-rhel9-operator@sha256:fa39e1d8ad329ebe341598df25dae4a388b34c28056732ed519ca8c3acb265c7
+    name: ""
+  - image: registry.redhat.io/rhel9/postgresql-16@sha256:e9a9876e2655647ed6fa5de78e18277eb3954ab8ee985a0cfda16e259a765a44
     name: postgresql
 schema: olm.bundle


### PR DESCRIPTION
I ran the migration script.  We received a report on deprecations happening tomorrow so this needs to get resolved soon. Specifically the concern is around task-prefetch-dependencies-oci-ta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated pinned pipeline task bundles across standard, FBC, OCI, staging, and base pipeline configurations.
  - Refreshed dependency prefetching and image-building tasks while preserving existing pipeline structure.
  - Applied consistent task reference updates across supported pipeline variants.

- **Updates**
  - Added operator version 1.8.1 to the release-1.8 catalog, replacing version 1.8.0.
  - Refreshed operator, component, and related image references, release metadata, and documentation for the new release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->